### PR TITLE
Actualizar paleta: tema claro pastel y tema oscuro violeta

### DIFF
--- a/src/web/src/app/routes/AuthGuard.tsx
+++ b/src/web/src/app/routes/AuthGuard.tsx
@@ -5,7 +5,7 @@ export const AuthGuard = () => {
   const { user, isLoading } = useAuth()
 
   if (isLoading) {
-    return <div className="p-8 text-sm text-slate-600">Checking authentication...</div>
+    return <div className="p-8 text-sm text-violet-700 dark:text-violet-300">Checking authentication...</div>
   }
 
   if (!user) {

--- a/src/web/src/app/routes/PublicOnlyGuard.tsx
+++ b/src/web/src/app/routes/PublicOnlyGuard.tsx
@@ -5,7 +5,7 @@ export const PublicOnlyGuard = () => {
   const { user, isLoading } = useAuth()
 
   if (isLoading) {
-    return <div className="p-8 text-sm text-slate-600">Checking authentication...</div>
+    return <div className="p-8 text-sm text-violet-700 dark:text-violet-300">Checking authentication...</div>
   }
 
   if (user) {

--- a/src/web/src/features/auth/LoginPage.tsx
+++ b/src/web/src/features/auth/LoginPage.tsx
@@ -20,14 +20,14 @@ export const LoginPage = () => {
     <main className="mx-auto flex min-h-screen w-full max-w-md items-center px-4">
       <Card className="w-full space-y-4">
         <div className="space-y-2 text-center">
-          <h1 className="text-2xl font-bold text-slate-900">HabitTracker</h1>
-          <p className="text-sm text-slate-600">Train. Log. Improve.</p>
+          <h1 className="text-2xl font-bold text-violet-950 dark:text-violet-100">HabitTracker</h1>
+          <p className="text-sm text-violet-700 dark:text-violet-300">Train. Log. Improve.</p>
         </div>
         <Button className="w-full" loading={isLoading} onClick={onContinue} size="lg">
           {isLoading ? 'Signing in...' : 'Continue with Google'}
         </Button>
         {error && <p className="text-center text-sm text-red-600">{error}</p>}
-        <p className="text-center text-xs text-slate-500">Secure sign-in</p>
+        <p className="text-center text-xs text-violet-500 dark:text-violet-400">Secure sign-in</p>
       </Card>
     </main>
   )

--- a/src/web/src/features/exercises/ExercisesPage.tsx
+++ b/src/web/src/features/exercises/ExercisesPage.tsx
@@ -121,10 +121,10 @@ export const ExercisesPage = () => {
       {!isLoading && filtered.length > 0 && (
         <Card className="space-y-3">
           {filtered.map((item) => (
-            <article className="flex items-start justify-between gap-3 border-b border-slate-100 pb-3 last:border-b-0 last:pb-0" key={item.id}>
+            <article className="flex items-start justify-between gap-3 border-b border-violet-100 dark:border-violet-900/60 pb-3 last:border-b-0 last:pb-0" key={item.id}>
               <div>
-                <h2 className="text-base font-semibold text-slate-900">{item.name}</h2>
-                <p className="text-xs text-slate-500">{item.muscle} • {item.equipment}</p>
+                <h2 className="text-base font-semibold text-violet-950 dark:text-violet-100">{item.name}</h2>
+                <p className="text-xs text-violet-500 dark:text-violet-400">{item.muscle}  {item.equipment}</p>
               </div>
               <div className="flex gap-2">
                 <Button onClick={() => openEdit(item)} size="sm" variant="ghost">

--- a/src/web/src/features/history/HistoryPage.tsx
+++ b/src/web/src/features/history/HistoryPage.tsx
@@ -33,13 +33,13 @@ export const HistoryPage = () => {
             <Button size="sm" variant="ghost">
               Prev
             </Button>
-            <h2 className="text-lg font-semibold text-slate-900">Feb 2026</h2>
+            <h2 className="text-lg font-semibold text-violet-950 dark:text-violet-100">Feb 2026</h2>
             <Button size="sm" variant="ghost">
               Next
             </Button>
           </div>
 
-          <div className="grid grid-cols-7 gap-1 text-center text-xs font-medium text-slate-500">
+          <div className="grid grid-cols-7 gap-1 text-center text-xs font-medium text-violet-500 dark:text-violet-400">
             {weekdayLabels.map((label) => (
               <span key={label}>{label}</span>
             ))}
@@ -48,7 +48,7 @@ export const HistoryPage = () => {
           <div className="grid grid-cols-7 gap-1">
             {monthCells.map((cell, index) => (
               <button
-                className="min-h-11 rounded-lg border border-slate-200 p-1 text-sm text-slate-700 disabled:border-transparent disabled:bg-transparent"
+                className="min-h-11 rounded-lg border border-violet-200 dark:border-violet-800 p-1 text-sm text-violet-800 dark:text-violet-200 disabled:border-transparent disabled:bg-transparent"
                 disabled={cell.label.length === 0}
                 key={`${cell.label}-${index}`}
                 onClick={() => {
@@ -59,7 +59,7 @@ export const HistoryPage = () => {
                 type="button"
               >
                 <span className="block">{cell.label}</span>
-                {cell.hasWorkout && <span className="mx-auto mt-1 block h-1.5 w-1.5 rounded-full bg-teal-600" />}
+                {cell.hasWorkout && <span className="mx-auto mt-1 block h-1.5 w-1.5 rounded-full bg-violet-600" />}
               </button>
             ))}
           </div>
@@ -75,14 +75,14 @@ export const HistoryPage = () => {
 
       <Drawer onClose={() => setSelectedDay(null)} open={Boolean(selectedDay)} title={selectedLabel || 'Workout Detail'}>
         <div className="space-y-3">
-          <p className="text-sm text-slate-700">Pull - PPL V1</p>
-          <div className="rounded-lg border border-slate-200 p-3">
-            <p className="text-sm font-semibold text-slate-900">Lat Pulldown</p>
-            <p className="text-xs text-slate-600">10x55, 8x60</p>
+          <p className="text-sm text-violet-800 dark:text-violet-200">Pull - PPL V1</p>
+          <div className="rounded-lg border border-violet-200 dark:border-violet-800 p-3">
+            <p className="text-sm font-semibold text-violet-950 dark:text-violet-100">Lat Pulldown</p>
+            <p className="text-xs text-violet-700 dark:text-violet-300">10x55, 8x60</p>
           </div>
-          <div className="rounded-lg border border-slate-200 p-3">
-            <p className="text-sm font-semibold text-slate-900">Seated Row</p>
-            <p className="text-xs text-slate-600">12x45, 10x50</p>
+          <div className="rounded-lg border border-violet-200 dark:border-violet-800 p-3">
+            <p className="text-sm font-semibold text-violet-950 dark:text-violet-100">Seated Row</p>
+            <p className="text-xs text-violet-700 dark:text-violet-300">12x45, 10x50</p>
           </div>
         </div>
       </Drawer>

--- a/src/web/src/features/modules/ModuleSelectPage.tsx
+++ b/src/web/src/features/modules/ModuleSelectPage.tsx
@@ -21,8 +21,8 @@ export const ModuleSelectPage = () => {
         <Skeleton variant="card" />
       ) : (
         <Card className="space-y-3">
-          <p className="text-sm font-semibold text-slate-900">GYM</p>
-          <p className="text-sm text-slate-600">Strength and hypertrophy logging.</p>
+          <p className="text-sm font-semibold text-violet-950 dark:text-violet-100">GYM</p>
+          <p className="text-sm text-violet-700 dark:text-violet-300">Strength and hypertrophy logging.</p>
           <Button className="w-full sm:w-auto" loading={isSaving} onClick={onContinue}>
             Continue
           </Button>

--- a/src/web/src/features/routines/RoutineBuilderPage.tsx
+++ b/src/web/src/features/routines/RoutineBuilderPage.tsx
@@ -99,10 +99,10 @@ export const RoutineBuilderPage = () => {
       {selectedDay.exercises.length > 0 && (
         <Card className="space-y-2">
           {selectedDay.exercises.map((exercise, index) => (
-            <div className="flex items-center justify-between rounded-lg border border-slate-200 p-3" key={`${exercise}-${index}`}>
+            <div className="flex items-center justify-between rounded-lg border border-violet-200 dark:border-violet-800 p-3" key={`${exercise}-${index}`}>
               <div>
-                <p className="text-sm font-semibold text-slate-900">{exercise}</p>
-                <p className="text-xs text-slate-500">Drag placeholder [::]</p>
+                <p className="text-sm font-semibold text-violet-950 dark:text-violet-100">{exercise}</p>
+                <p className="text-xs text-violet-500 dark:text-violet-400">Drag placeholder [::]</p>
               </div>
               <Button onClick={() => onRemove(index)} size="sm" variant="ghost">
                 Remove

--- a/src/web/src/features/routines/RoutinesPage.tsx
+++ b/src/web/src/features/routines/RoutinesPage.tsx
@@ -72,9 +72,9 @@ export const RoutinesPage = () => {
       {!isLoading && items.length > 0 && (
         <Card className="space-y-3">
           {items.map((item) => (
-            <article className="flex items-center justify-between gap-3 border-b border-slate-100 pb-3 last:border-b-0 last:pb-0" key={item.id}>
+            <article className="flex items-center justify-between gap-3 border-b border-violet-100 dark:border-violet-900/60 pb-3 last:border-b-0 last:pb-0" key={item.id}>
               <div className="space-y-1">
-                <h2 className="text-base font-semibold text-slate-900">{item.name}</h2>
+                <h2 className="text-base font-semibold text-violet-950 dark:text-violet-100">{item.name}</h2>
                 <div className="flex items-center gap-2">
                   <Badge tone="info">{item.type}</Badge>
                   {item.active && <Badge tone="active">Active</Badge>}
@@ -87,7 +87,7 @@ export const RoutinesPage = () => {
                   </Button>
                 )}
                 <Link
-                  className="inline-flex min-h-10 items-center justify-center rounded-xl border border-slate-200 px-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                  className="inline-flex min-h-10 items-center justify-center rounded-xl border border-violet-200 dark:border-violet-800 px-3 text-sm font-semibold text-violet-800 dark:text-violet-200 transition hover:bg-violet-100 dark:hover:bg-violet-900/70"
                   to={`/app/routines/${item.id}`}
                 >
                   Open

--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -91,7 +91,7 @@ export const LogWorkoutPage = () => {
   return (
     <AppShell subtitle="Tue, Feb 25" title="Today: Pull">
       <Card className="space-y-2">
-        <p className="text-sm text-slate-700">Active: PPL - V1</p>
+        <p className="text-sm text-violet-800 dark:text-violet-200">Active: PPL - V1</p>
         <Badge tone="info">today only edits</Badge>
       </Card>
 
@@ -123,13 +123,13 @@ export const LogWorkoutPage = () => {
       {items.map((exercise) => (
         <Card className="space-y-3" key={exercise.id}>
           <div className="flex items-center justify-between">
-            <h2 className="text-base font-semibold text-slate-900">{exercise.name}</h2>
+            <h2 className="text-base font-semibold text-violet-950 dark:text-violet-100">{exercise.name}</h2>
             <Button onClick={() => removeExercise(exercise.id)} size="sm" variant="ghost">
               Remove
             </Button>
           </div>
 
-          <div className="grid grid-cols-4 gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <div className="grid grid-cols-4 gap-2 text-xs font-semibold uppercase tracking-wide text-violet-500 dark:text-violet-400">
             <span>Set</span>
             <span>Reps</span>
             <span>Kg</span>
@@ -138,7 +138,7 @@ export const LogWorkoutPage = () => {
 
           {exercise.sets.map((set, index) => (
             <div className="grid grid-cols-4 gap-2" key={set.id}>
-              <div className="flex min-h-11 items-center rounded-lg border border-slate-200 px-3 text-sm text-slate-700">
+              <div className="flex min-h-11 items-center rounded-lg border border-violet-200 dark:border-violet-800 px-3 text-sm text-violet-800 dark:text-violet-200">
                 {index + 1}
               </div>
               <Input
@@ -174,7 +174,7 @@ export const LogWorkoutPage = () => {
         </Card>
       ))}
 
-      <div className="sticky bottom-20 z-10 rounded-2xl bg-slate-50 pt-2">
+      <div className="sticky bottom-20 z-10 rounded-2xl bg-violet-50 dark:bg-violet-950 pt-2">
         <Button className="w-full shadow-[0_-4px_12px_rgba(15,23,42,0.08)]" loading={isSaving} onClick={onSave}>
           {isSaving ? 'Saving...' : 'Save Workout'}
         </Button>

--- a/src/web/src/shared/components/AppShell.tsx
+++ b/src/web/src/shared/components/AppShell.tsx
@@ -23,7 +23,7 @@ export const AppShell = ({
   const navigate = useNavigate()
 
   return (
-    <div className="min-h-screen bg-slate-50 pb-24">
+    <div className="min-h-screen bg-violet-50 dark:bg-violet-950 pb-24">
       <TopBar
         onBack={onBack ?? (withNav ? undefined : () => navigate(-1))}
         rightAction={rightAction}

--- a/src/web/src/shared/components/Badge.tsx
+++ b/src/web/src/shared/components/Badge.tsx
@@ -8,8 +8,8 @@ type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
 }
 
 const toneClasses: Record<BadgeTone, string> = {
-  default: 'bg-slate-100 text-slate-700',
-  active: 'bg-teal-100 text-teal-700',
+  default: 'bg-violet-100 dark:bg-violet-900/70 text-violet-800 dark:text-violet-200',
+  active: 'bg-violet-200 dark:bg-violet-800 text-violet-800 dark:text-violet-200',
   info: 'bg-blue-100 text-blue-700',
   success: 'bg-emerald-100 text-emerald-700',
   warning: 'bg-amber-100 text-amber-700',

--- a/src/web/src/shared/components/BottomNav.tsx
+++ b/src/web/src/shared/components/BottomNav.tsx
@@ -14,7 +14,7 @@ type BottomNavProps = {
 }
 
 export const BottomNav = ({ items = defaultItems }: BottomNavProps) => (
-  <nav className="fixed inset-x-0 bottom-0 z-30 border-t border-slate-200 bg-white px-2 pb-2 pt-2 md:left-1/2 md:max-w-3xl md:-translate-x-1/2 md:rounded-t-2xl md:border md:shadow-lg">
+  <nav className="fixed inset-x-0 bottom-0 z-30 border-t border-violet-200 dark:border-violet-800 bg-violet-50/80 dark:bg-violet-900/50 px-2 pb-2 pt-2 md:left-1/2 md:max-w-3xl md:-translate-x-1/2 md:rounded-t-2xl md:border md:shadow-lg">
     <ul className="grid grid-cols-4 gap-1">
       {items.map((item) => (
         <li key={item.key}>
@@ -22,7 +22,7 @@ export const BottomNav = ({ items = defaultItems }: BottomNavProps) => (
             className={({ isActive }) =>
               cn(
                 'flex min-h-11 items-center justify-center rounded-lg px-2 text-sm font-medium transition',
-                isActive ? 'bg-teal-100 text-teal-700' : 'text-slate-600 hover:bg-slate-100',
+                isActive ? 'bg-violet-200 dark:bg-violet-800 text-violet-800 dark:text-violet-200' : 'text-violet-700 dark:text-violet-300 hover:bg-violet-100 dark:hover:bg-violet-900/70',
               )
             }
             to={item.to}

--- a/src/web/src/shared/components/Button.tsx
+++ b/src/web/src/shared/components/Button.tsx
@@ -11,11 +11,11 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    'bg-teal-600 text-white hover:bg-teal-700 focus-visible:outline-teal-600 disabled:bg-slate-300 disabled:text-slate-600',
+    'bg-violet-600 text-white hover:bg-violet-500 focus-visible:outline-violet-500 disabled:bg-violet-300 dark:disabled:bg-violet-800 disabled:text-violet-700 dark:disabled:text-violet-300',
   secondary:
-    'border border-slate-200 bg-white text-slate-800 hover:bg-slate-50 focus-visible:outline-slate-500 disabled:text-slate-400',
+    'border border-violet-200 dark:border-violet-800 bg-violet-50/80 dark:bg-violet-900/50 text-violet-900 dark:text-violet-100 hover:bg-violet-100 dark:hover:bg-violet-900/70 focus-visible:outline-violet-500 disabled:text-violet-400 dark:disabled:text-violet-500',
   ghost:
-    'bg-transparent text-slate-700 hover:bg-slate-100 focus-visible:outline-slate-500 disabled:text-slate-400',
+    'bg-transparent text-violet-800 dark:text-violet-200 hover:bg-violet-100 dark:hover:bg-violet-900/70 focus-visible:outline-violet-500 disabled:text-violet-400 dark:disabled:text-violet-500',
 }
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/src/web/src/shared/components/Card.tsx
+++ b/src/web/src/shared/components/Card.tsx
@@ -5,7 +5,7 @@ type CardProps = HTMLAttributes<HTMLDivElement>
 
 export const Card = ({ className, ...props }: CardProps) => (
   <div
-    className={cn('rounded-2xl border border-slate-200 bg-white p-4 shadow-sm', className)}
+    className={cn('rounded-2xl border border-violet-200 dark:border-violet-800 bg-violet-50/80 dark:bg-violet-900/50 p-4 shadow-sm', className)}
     {...props}
   />
 )

--- a/src/web/src/shared/components/Drawer.tsx
+++ b/src/web/src/shared/components/Drawer.tsx
@@ -29,15 +29,15 @@ export const Drawer = ({ open, title, onClose, children }: DrawerProps) => {
   }
 
   return (
-    <div className="fixed inset-0 z-40 bg-slate-900/50" onClick={onClose}>
+    <div className="fixed inset-0 z-40 bg-violet-950/70" onClick={onClose}>
       <div
         aria-modal="true"
-        className="absolute inset-x-0 bottom-0 max-h-[80vh] overflow-y-auto rounded-t-2xl bg-white shadow-lg"
+        className="absolute inset-x-0 bottom-0 max-h-[80vh] overflow-y-auto rounded-t-2xl bg-violet-50/80 dark:bg-violet-900/50 shadow-lg"
         onClick={(event) => event.stopPropagation()}
         role="dialog"
       >
-        <header className="sticky top-0 flex items-center justify-between border-b border-slate-200 bg-white px-4 py-3">
-          <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        <header className="sticky top-0 flex items-center justify-between border-b border-violet-200 dark:border-violet-800 bg-violet-50/80 dark:bg-violet-900/50 px-4 py-3">
+          <h2 className="text-lg font-semibold text-violet-950 dark:text-violet-100">{title}</h2>
           <Button aria-label="Close" onClick={onClose} size="sm" variant="ghost">
             Close
           </Button>

--- a/src/web/src/shared/components/EmptyState.tsx
+++ b/src/web/src/shared/components/EmptyState.tsx
@@ -7,9 +7,9 @@ type EmptyStateProps = {
 }
 
 export const EmptyState = ({ title, description, action }: EmptyStateProps) => (
-  <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-6 text-center">
-    <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-    <p className="mt-1 text-sm text-slate-600">{description}</p>
+  <div className="rounded-2xl border border-dashed border-violet-300 dark:border-violet-700 bg-violet-50 dark:bg-violet-950 p-6 text-center">
+    <h3 className="text-lg font-semibold text-violet-950 dark:text-violet-100">{title}</h3>
+    <p className="mt-1 text-sm text-violet-700 dark:text-violet-300">{description}</p>
     {action && <div className="mt-4">{action}</div>}
   </div>
 )

--- a/src/web/src/shared/components/Input.tsx
+++ b/src/web/src/shared/components/Input.tsx
@@ -12,20 +12,20 @@ export const Input = ({ id, label, helperText, error, className, ...props }: Inp
 
   return (
     <label className="block space-y-1.5" htmlFor={id}>
-      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <span className="text-sm font-medium text-violet-800 dark:text-violet-200">{label}</span>
       <input
         aria-describedby={describedBy}
         aria-invalid={Boolean(error)}
         className={cn(
-          'min-h-11 w-full rounded-lg border bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-teal-500/30',
-          error ? 'border-red-500 focus-visible:border-red-500' : 'border-slate-200 focus-visible:border-teal-600',
+          'min-h-11 w-full rounded-lg border bg-violet-50/80 dark:bg-violet-900/50 px-3 py-2 text-sm text-violet-950 dark:text-violet-100 outline-none transition placeholder:text-violet-400 dark:placeholder:text-violet-500 focus-visible:ring-2 focus-visible:ring-violet-500/30',
+          error ? 'border-red-500 focus-visible:border-red-500' : 'border-violet-200 dark:border-violet-800 focus-visible:border-violet-500',
           className,
         )}
         id={id}
         {...props}
       />
       {helperText && !error && (
-        <p className="text-xs text-slate-500" id={`${id}-help`}>
+        <p className="text-xs text-violet-500 dark:text-violet-400" id={`${id}-help`}>
           {helperText}
         </p>
       )}

--- a/src/web/src/shared/components/Modal.tsx
+++ b/src/web/src/shared/components/Modal.tsx
@@ -32,23 +32,23 @@ export const Modal = ({ open, title, onClose, children, footer, className }: Mod
   }
 
   return (
-    <div className="fixed inset-0 z-40 flex items-end bg-slate-900/50 p-4 md:items-center md:justify-center">
+    <div className="fixed inset-0 z-40 flex items-end bg-violet-950/70 p-4 md:items-center md:justify-center">
       <div
         aria-modal="true"
         className={cn(
-          'w-full max-w-lg rounded-2xl border border-slate-200 bg-white shadow-lg',
+          'w-full max-w-lg rounded-2xl border border-violet-200 dark:border-violet-800 bg-violet-50/80 dark:bg-violet-900/50 shadow-lg',
           className,
         )}
         role="dialog"
       >
-        <header className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
-          <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        <header className="flex items-center justify-between border-b border-violet-200 dark:border-violet-800 px-4 py-3">
+          <h2 className="text-lg font-semibold text-violet-950 dark:text-violet-100">{title}</h2>
           <Button aria-label="Close" onClick={onClose} size="sm" variant="ghost">
             Close
           </Button>
         </header>
         <div className="space-y-3 p-4">{children}</div>
-        {footer && <footer className="border-t border-slate-200 p-4">{footer}</footer>}
+        {footer && <footer className="border-t border-violet-200 dark:border-violet-800 p-4">{footer}</footer>}
       </div>
     </div>
   )

--- a/src/web/src/shared/components/Select.tsx
+++ b/src/web/src/shared/components/Select.tsx
@@ -22,13 +22,13 @@ export const Select = ({
 
   return (
     <label className="block space-y-1.5" htmlFor={id}>
-      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <span className="text-sm font-medium text-violet-800 dark:text-violet-200">{label}</span>
       <select
         aria-describedby={describedBy}
         aria-invalid={Boolean(error)}
         className={cn(
-          'min-h-11 w-full rounded-lg border bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus-visible:ring-2 focus-visible:ring-teal-500/30',
-          error ? 'border-red-500 focus-visible:border-red-500' : 'border-slate-200 focus-visible:border-teal-600',
+          'min-h-11 w-full rounded-lg border bg-violet-50/80 dark:bg-violet-900/50 px-3 py-2 text-sm text-violet-950 dark:text-violet-100 outline-none transition focus-visible:ring-2 focus-visible:ring-violet-500/30',
+          error ? 'border-red-500 focus-visible:border-red-500' : 'border-violet-200 dark:border-violet-800 focus-visible:border-violet-500',
           className,
         )}
         id={id}
@@ -41,7 +41,7 @@ export const Select = ({
         ))}
       </select>
       {helperText && !error && (
-        <p className="text-xs text-slate-500" id={`${id}-help`}>
+        <p className="text-xs text-violet-500 dark:text-violet-400" id={`${id}-help`}>
           {helperText}
         </p>
       )}

--- a/src/web/src/shared/components/Skeleton.tsx
+++ b/src/web/src/shared/components/Skeleton.tsx
@@ -16,6 +16,6 @@ const variantClasses: Record<SkeletonVariant, string> = {
 export const Skeleton = ({ variant = 'row', className }: SkeletonProps) => (
   <div
     aria-hidden="true"
-    className={cn('animate-pulse bg-slate-200', variantClasses[variant], className)}
+    className={cn('animate-pulse bg-violet-200 dark:bg-violet-800', variantClasses[variant], className)}
   />
 )

--- a/src/web/src/shared/components/Textarea.tsx
+++ b/src/web/src/shared/components/Textarea.tsx
@@ -12,20 +12,20 @@ export const Textarea = ({ id, label, helperText, error, className, ...props }: 
 
   return (
     <label className="block space-y-1.5" htmlFor={id}>
-      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <span className="text-sm font-medium text-violet-800 dark:text-violet-200">{label}</span>
       <textarea
         aria-describedby={describedBy}
         aria-invalid={Boolean(error)}
         className={cn(
-          'min-h-24 w-full rounded-lg border bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-teal-500/30',
-          error ? 'border-red-500 focus-visible:border-red-500' : 'border-slate-200 focus-visible:border-teal-600',
+          'min-h-24 w-full rounded-lg border bg-violet-50/80 dark:bg-violet-900/50 px-3 py-2 text-sm text-violet-950 dark:text-violet-100 outline-none transition placeholder:text-violet-400 dark:placeholder:text-violet-500 focus-visible:ring-2 focus-visible:ring-violet-500/30',
+          error ? 'border-red-500 focus-visible:border-red-500' : 'border-violet-200 dark:border-violet-800 focus-visible:border-violet-500',
           className,
         )}
         id={id}
         {...props}
       />
       {helperText && !error && (
-        <p className="text-xs text-slate-500" id={`${id}-help`}>
+        <p className="text-xs text-violet-500 dark:text-violet-400" id={`${id}-help`}>
           {helperText}
         </p>
       )}

--- a/src/web/src/shared/components/TopBar.tsx
+++ b/src/web/src/shared/components/TopBar.tsx
@@ -9,7 +9,7 @@ type TopBarProps = {
 }
 
 export const TopBar = ({ title, subtitle, onBack, rightAction }: TopBarProps) => (
-  <header className="sticky top-0 z-20 border-b border-slate-200 bg-slate-50/95 px-4 py-3 backdrop-blur">
+  <header className="sticky top-0 z-20 border-b border-violet-200 dark:border-violet-800 bg-violet-50 dark:bg-violet-950/95 px-4 py-3 backdrop-blur">
     <div className="mx-auto flex w-full max-w-3xl items-start justify-between gap-3">
       <div className="flex items-start gap-2">
         {onBack && (
@@ -18,8 +18,8 @@ export const TopBar = ({ title, subtitle, onBack, rightAction }: TopBarProps) =>
           </Button>
         )}
         <div>
-          <h1 className="text-xl font-semibold text-slate-900">{title}</h1>
-          {subtitle && <p className="text-xs text-slate-500">{subtitle}</p>}
+          <h1 className="text-xl font-semibold text-violet-950 dark:text-violet-100">{title}</h1>
+          {subtitle && <p className="text-xs text-violet-500 dark:text-violet-400">{subtitle}</p>}
         </div>
       </div>
       {rightAction}

--- a/src/web/src/styles/globals.css
+++ b/src/web/src/styles/globals.css
@@ -1,14 +1,29 @@
 @import "tailwindcss";
 
 @layer base {
+  :root {
+    color-scheme: light;
+  }
+
   body {
-    background-color: #f8fafc;
-    color: #0f172a;
+    background: linear-gradient(180deg, #fdf4ff 0%, #f5f3ff 45%, #eef2ff 100%);
+    color: #3b0764;
     font-family: "Plus Jakarta Sans", "Manrope", "Segoe UI", sans-serif;
   }
 
   *:focus-visible {
-    outline: 2px solid #0ea5a4;
+    outline: 2px solid #7c3aed;
     outline-offset: 2px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
+    }
+
+    body {
+      background: radial-gradient(circle at top, #581c87 0%, #2e1065 38%, #0f0224 100%);
+      color: #ede9fe;
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Cambiar la apariencia para que el `modo oscuro` use un morado/violeta moderno como color principal y el `modo claro` use tonos pastel para evitar blancos duros. 
- Unificar la identidad visual en todos los componentes compartidos para que los elementos (botones, tarjetas, inputs, modales, nav) se sientan coherentes entre modos.

### Description
- Reemplazado el foundation global en `src/web/src/styles/globals.css` para aplicar un degradado pastel en claro y un fondo radial violeta en oscuro, y ajustar `color-scheme` y estilos de foco. 
- Actualizados componentes compartidos en `src/web/src/shared/components/*` (por ejemplo `Button.tsx`, `Input.tsx`, `Select.tsx`, `Card.tsx`, `Modal.tsx`, `Drawer.tsx`, `TopBar.tsx`, `BottomNav.tsx`, `Badge.tsx`, `Skeleton.tsx`, `Textarea.tsx`) para usar tokens violet/pastel y variantes `dark:` consistentes. 
- Aplicados cambios en páginas principales para mantener coherencia (p. ej. `HistoryPage.tsx`, `LoginPage.tsx`, `ModuleSelectPage.tsx`, `RoutinesPage.tsx`, `ExercisesPage.tsx`, `LogWorkoutPage.tsx`). 
- Total de archivos modificados: 23 (colores y clases CSS/Tailwind actualizadas) y se incluyó una captura de la UI actualizada como artifact del despliegue local.

### Testing
- Ejecutado `npm run lint` dentro de `src/web` y pasó correctamente. 
- Ejecutado `npm run build` dentro de `src/web` y falló por problemas preexistentes en el repo fuera del scope de este cambio (imports/tipos no resueltos como `react-router-dom`, `firebase/*`, y `shared/types/firestore`). 
- Levanté el servidor de desarrollo y capturé una captura de pantalla del resultado para validación visual del tema (artifact generado durante la verificación local).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f450b098c83218dd210a3db5c8487)