### PR TITLE
Modernize UI with pastel minimal redesign, updated primitives and local SVG icons

### DIFF
--- a/src/web/src/shared/components/AppShell.tsx
+++ b/src/web/src/shared/components/AppShell.tsx
@@ -1,9 +1,10 @@
-﻿import { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ReactNode } from 'react'
 import { BottomNav } from './BottomNav'
 import { Button } from './Button'
 import { TopBar } from './TopBar'
+import { IconMoon, IconSparkles, IconSun } from './icons'
 
 type AppShellProps = {
   title: string
@@ -55,6 +56,7 @@ export const AppShell = ({
           <div className="flex items-center gap-2">
             {rightAction}
             <Button
+              leadingIcon={theme === 'light' ? <IconMoon className="h-4 w-4" /> : <IconSun className="h-4 w-4" />}
               onClick={() => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))}
               size="sm"
               variant="secondary"
@@ -66,7 +68,13 @@ export const AppShell = ({
         subtitle={subtitle}
         title={title}
       />
-      <main className="mx-auto w-full max-w-3xl space-y-4 px-4 py-4">{children}</main>
+      <main className="mx-auto w-full max-w-3xl space-y-4 px-4 py-4">
+        <div className="inline-flex items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--surface-1)] px-2.5 py-1 text-xs font-semibold text-[var(--text-muted)]">
+          <IconSparkles className="h-3.5 w-3.5" />
+          Focus mode
+        </div>
+        {children}
+      </main>
       {withNav && <BottomNav />}
     </div>
   )

--- a/src/web/src/shared/components/Badge.tsx
+++ b/src/web/src/shared/components/Badge.tsx
@@ -1,4 +1,4 @@
-﻿import type { HTMLAttributes } from 'react'
+import type { HTMLAttributes } from 'react'
 import { cn } from '../lib/cn'
 
 type BadgeTone = 'default' | 'active' | 'info' | 'success' | 'warning'
@@ -8,7 +8,7 @@ type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
 }
 
 const toneClasses: Record<BadgeTone, string> = {
-  default: 'bg-[var(--surface-3)] text-[var(--text)]',
+  default: 'bg-[var(--surface-2)] text-[var(--text)]',
   active: 'bg-[var(--accent-soft)] text-[var(--accent-text)]',
   info: 'bg-sky-100 text-sky-700',
   success: 'bg-emerald-100 text-emerald-700',
@@ -18,7 +18,7 @@ const toneClasses: Record<BadgeTone, string> = {
 export const Badge = ({ tone = 'default', className, ...props }: BadgeProps) => (
   <span
     className={cn(
-      'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold',
+      'inline-flex items-center rounded-full border border-[var(--border-muted)] px-2.5 py-1 text-xs font-semibold',
       toneClasses[tone],
       className,
     )}

--- a/src/web/src/shared/components/BottomNav.tsx
+++ b/src/web/src/shared/components/BottomNav.tsx
@@ -1,6 +1,8 @@
-﻿import { NavLink } from 'react-router-dom'
+import type { ComponentType, SVGProps } from 'react'
+import { NavLink } from 'react-router-dom'
 import { cn } from '../lib/cn'
-import type { BottomNavItem } from '../types/ui'
+import type { BottomNavItem, BottomNavKey } from '../types/ui'
+import { IconChart, IconChecklist, IconDumbbell, IconLibrary } from './icons'
 
 const defaultItems: BottomNavItem[] = [
   { key: 'workout', label: 'Workout', to: '/app/workout' },
@@ -9,30 +11,42 @@ const defaultItems: BottomNavItem[] = [
   { key: 'history', label: 'History', to: '/app/history' },
 ]
 
+const navIcons: Record<BottomNavKey, ComponentType<SVGProps<SVGSVGElement>>> = {
+  workout: IconDumbbell,
+  exercises: IconLibrary,
+  routines: IconChecklist,
+  history: IconChart,
+}
+
 type BottomNavProps = {
   items?: BottomNavItem[]
 }
 
 export const BottomNav = ({ items = defaultItems }: BottomNavProps) => (
-  <nav className="fixed inset-x-0 bottom-0 z-30 border-t border-[var(--border)] bg-[color:var(--surface-1)]/95 px-2 pb-2 pt-2 backdrop-blur md:left-1/2 md:max-w-3xl md:-translate-x-1/2 md:rounded-t-2xl md:border md:shadow-[var(--card-shadow)]">
+  <nav className="fixed inset-x-0 bottom-0 z-30 border-t border-[var(--border)] bg-[color:var(--surface-1)]/95 px-2 pb-2 pt-2 backdrop-blur-xl md:left-1/2 md:max-w-3xl md:-translate-x-1/2 md:rounded-t-3xl md:border md:shadow-[var(--card-shadow)]">
     <ul className="grid grid-cols-4 gap-1">
-      {items.map((item) => (
-        <li key={item.key}>
-          <NavLink
-            className={({ isActive }) =>
-              cn(
-                'flex min-h-11 items-center justify-center rounded-lg px-2 text-sm font-medium transition',
-                isActive
-                  ? 'bg-[var(--accent-soft)] text-[var(--accent-text)]'
-                  : 'text-[var(--text-muted)] hover:bg-[var(--surface-2)]',
-              )
-            }
-            to={item.to}
-          >
-            {item.label}
-          </NavLink>
-        </li>
-      ))}
+      {items.map((item) => {
+        const Icon = navIcons[item.key]
+
+        return (
+          <li key={item.key}>
+            <NavLink
+              className={({ isActive }) =>
+                cn(
+                  'flex min-h-12 flex-col items-center justify-center gap-0.5 rounded-2xl px-2 text-[11px] font-semibold transition',
+                  isActive
+                    ? 'bg-[var(--accent-soft)] text-[var(--accent-text)]'
+                    : 'text-[var(--text-muted)] hover:bg-[var(--surface-2)]',
+                )
+              }
+              to={item.to}
+            >
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </NavLink>
+          </li>
+        )
+      })}
     </ul>
   </nav>
 )

--- a/src/web/src/shared/components/Button.tsx
+++ b/src/web/src/shared/components/Button.tsx
@@ -1,4 +1,4 @@
-﻿import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 import { cn } from '../lib/cn'
 import type { ButtonSize, ButtonVariant } from '../types/ui'
 
@@ -11,16 +11,16 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    'bg-[var(--accent)] text-[var(--accent-contrast)] hover:bg-[var(--accent-hover)] focus-visible:outline-[var(--accent)] disabled:bg-[var(--surface-3)] disabled:text-[var(--text-muted)]',
+    'bg-[var(--accent)] text-[var(--accent-contrast)] shadow-[0_10px_24px_rgba(153,99,239,0.32)] hover:-translate-y-0.5 hover:bg-[var(--accent-hover)] focus-visible:outline-[var(--accent)] disabled:bg-[var(--surface-3)] disabled:text-[var(--text-muted)] disabled:shadow-none',
   secondary:
-    'border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)] hover:bg-[var(--surface-3)] focus-visible:outline-[var(--border-strong)] disabled:text-[var(--text-muted)]',
+    'border border-[var(--border)] bg-[var(--surface-1)] text-[var(--text)] hover:-translate-y-0.5 hover:bg-[var(--surface-2)] focus-visible:outline-[var(--border-strong)] disabled:text-[var(--text-muted)]',
   ghost:
     'bg-transparent text-[var(--text)] hover:bg-[var(--surface-2)] focus-visible:outline-[var(--border-strong)] disabled:text-[var(--text-muted)]',
 }
 
 const sizeClasses: Record<ButtonSize, string> = {
-  sm: 'h-10 px-3 text-sm',
-  md: 'h-11 px-4 text-sm',
+  sm: 'h-10 px-3.5 text-sm',
+  md: 'h-11 px-4.5 text-sm',
   lg: 'h-12 px-5 text-base',
 }
 
@@ -37,7 +37,7 @@ export const Button = ({
 }: ButtonProps) => (
   <button
     className={cn(
-      'inline-flex min-h-11 items-center justify-center gap-2 rounded-xl font-semibold transition duration-150 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed',
+      'inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl font-semibold transition duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed',
       variantClasses[variant],
       sizeClasses[size],
       className,

--- a/src/web/src/shared/components/Card.tsx
+++ b/src/web/src/shared/components/Card.tsx
@@ -5,7 +5,10 @@ type CardProps = HTMLAttributes<HTMLDivElement>
 
 export const Card = ({ className, ...props }: CardProps) => (
   <div
-    className={cn('rounded-2xl border border-[var(--border)] bg-[var(--surface-1)] p-4 shadow-[var(--card-shadow)]', className)}
+    className={cn(
+      'rounded-3xl border border-[var(--border)] bg-[var(--surface-1)] p-5 shadow-[var(--card-shadow)] backdrop-blur-md',
+      className,
+    )}
     {...props}
   />
 )

--- a/src/web/src/shared/components/Input.tsx
+++ b/src/web/src/shared/components/Input.tsx
@@ -1,4 +1,4 @@
-﻿import type { InputHTMLAttributes } from 'react'
+import type { InputHTMLAttributes } from 'react'
 import { cn } from '../lib/cn'
 
 type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
@@ -12,12 +12,12 @@ export const Input = ({ id, label, helperText, error, className, ...props }: Inp
 
   return (
     <label className="block space-y-1.5" htmlFor={id}>
-      <span className="text-sm font-medium text-[var(--text)]">{label}</span>
+      <span className="text-sm font-semibold text-[var(--text)]">{label}</span>
       <input
         aria-describedby={describedBy}
         aria-invalid={Boolean(error)}
         className={cn(
-          'min-h-11 w-full rounded-lg border bg-[var(--surface-2)] px-3 py-2 text-sm text-[var(--text-strong)] outline-none transition placeholder:text-[var(--text-muted)] focus-visible:ring-2 focus-visible:ring-[color:var(--accent-soft)]',
+          'min-h-11 w-full rounded-2xl border bg-[var(--surface-1)] px-3.5 py-2 text-sm text-[var(--text-strong)] shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] outline-none transition placeholder:text-[var(--text-muted)] focus-visible:ring-3 focus-visible:ring-[color:var(--accent-soft)]',
           error
             ? 'border-red-500 focus-visible:border-red-500'
             : 'border-[var(--border)] focus-visible:border-[var(--accent)]',

--- a/src/web/src/shared/components/Select.tsx
+++ b/src/web/src/shared/components/Select.tsx
@@ -1,4 +1,4 @@
-﻿import type { SelectHTMLAttributes } from 'react'
+import type { SelectHTMLAttributes } from 'react'
 import { cn } from '../lib/cn'
 import type { FieldOption } from '../types/ui'
 
@@ -22,12 +22,12 @@ export const Select = ({
 
   return (
     <label className="block space-y-1.5" htmlFor={id}>
-      <span className="text-sm font-medium text-[var(--text)]">{label}</span>
+      <span className="text-sm font-semibold text-[var(--text)]">{label}</span>
       <select
         aria-describedby={describedBy}
         aria-invalid={Boolean(error)}
         className={cn(
-          'min-h-11 w-full rounded-lg border bg-[var(--surface-2)] px-3 py-2 text-sm text-[var(--text-strong)] outline-none transition focus-visible:ring-2 focus-visible:ring-[color:var(--accent-soft)]',
+          'min-h-11 w-full rounded-2xl border bg-[var(--surface-1)] px-3.5 py-2 text-sm text-[var(--text-strong)] shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] outline-none transition focus-visible:ring-3 focus-visible:ring-[color:var(--accent-soft)]',
           error
             ? 'border-red-500 focus-visible:border-red-500'
             : 'border-[var(--border)] focus-visible:border-[var(--accent)]',

--- a/src/web/src/shared/components/Textarea.tsx
+++ b/src/web/src/shared/components/Textarea.tsx
@@ -1,4 +1,4 @@
-﻿import type { TextareaHTMLAttributes } from 'react'
+import type { TextareaHTMLAttributes } from 'react'
 import { cn } from '../lib/cn'
 
 type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
@@ -12,12 +12,12 @@ export const Textarea = ({ id, label, helperText, error, className, ...props }: 
 
   return (
     <label className="block space-y-1.5" htmlFor={id}>
-      <span className="text-sm font-medium text-[var(--text)]">{label}</span>
+      <span className="text-sm font-semibold text-[var(--text)]">{label}</span>
       <textarea
         aria-describedby={describedBy}
         aria-invalid={Boolean(error)}
         className={cn(
-          'min-h-24 w-full rounded-lg border bg-[var(--surface-2)] px-3 py-2 text-sm text-[var(--text-strong)] outline-none transition placeholder:text-[var(--text-muted)] focus-visible:ring-2 focus-visible:ring-[color:var(--accent-soft)]',
+          'min-h-24 w-full rounded-2xl border bg-[var(--surface-1)] px-3.5 py-2 text-sm text-[var(--text-strong)] shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] outline-none transition placeholder:text-[var(--text-muted)] focus-visible:ring-3 focus-visible:ring-[color:var(--accent-soft)]',
           error
             ? 'border-red-500 focus-visible:border-red-500'
             : 'border-[var(--border)] focus-visible:border-[var(--accent)]',

--- a/src/web/src/shared/components/TopBar.tsx
+++ b/src/web/src/shared/components/TopBar.tsx
@@ -1,5 +1,6 @@
-﻿import type { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { Button } from './Button'
+import { IconChevronLeft } from './icons'
 
 type TopBarProps = {
   title: string
@@ -9,16 +10,16 @@ type TopBarProps = {
 }
 
 export const TopBar = ({ title, subtitle, onBack, rightAction }: TopBarProps) => (
-  <header className="sticky top-0 z-20 border-b border-[var(--border)] bg-[color:var(--surface-1)]/95 px-4 py-3 backdrop-blur">
+  <header className="sticky top-0 z-20 border-b border-[var(--border)] bg-[color:var(--surface-1)]/90 px-4 py-3 backdrop-blur-xl">
     <div className="mx-auto flex w-full max-w-3xl items-start justify-between gap-3">
       <div className="flex items-start gap-2">
         {onBack && (
-          <Button aria-label="Go back" onClick={onBack} size="sm" variant="ghost">
+          <Button aria-label="Go back" leadingIcon={<IconChevronLeft className="h-4 w-4" />} onClick={onBack} size="sm" variant="ghost">
             Back
           </Button>
         )}
         <div>
-          <h1 className="text-xl font-semibold text-[var(--text-strong)]">{title}</h1>
+          <h1 className="text-xl font-bold tracking-tight text-[var(--text-strong)]">{title}</h1>
           {subtitle && <p className="text-xs text-[var(--text-muted)]">{subtitle}</p>}
         </div>
       </div>

--- a/src/web/src/shared/components/icons.tsx
+++ b/src/web/src/shared/components/icons.tsx
@@ -1,0 +1,65 @@
+import type { SVGProps } from 'react'
+
+type IconProps = SVGProps<SVGSVGElement>
+
+const baseProps = {
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  strokeWidth: 1.8,
+  viewBox: '0 0 24 24',
+}
+
+export const IconChevronLeft = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <path d="m15 18-6-6 6-6" />
+  </svg>
+)
+
+export const IconMoon = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <path d="M21 12.7A9 9 0 1 1 11.3 3a7 7 0 1 0 9.7 9.7Z" />
+  </svg>
+)
+
+export const IconSun = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2.5M12 19.5V22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M2 12h2.5M19.5 12H22M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8" />
+  </svg>
+)
+
+export const IconSparkles = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <path d="m12 3 1.2 3.1L16 7.3l-2.8 1.2L12 12l-1.2-3.5L8 7.3l2.8-1.2z" />
+    <path d="m5 14 .7 1.8 1.8.7-1.8.7L5 19l-.7-1.8-1.8-.7 1.8-.7z" />
+    <path d="m19 13 .8 2 2 .8-2 .8-.8 2-.8-2-2-.8 2-.8z" />
+  </svg>
+)
+
+export const IconDumbbell = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <path d="M4 10v4M7 9v6M17 9v6M20 10v4" />
+    <path d="M7 12h10" />
+  </svg>
+)
+
+export const IconLibrary = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <path d="M4 5h5v14H4zM10 5h5v14h-5zM16 5h4v14h-4z" />
+  </svg>
+)
+
+export const IconChecklist = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <path d="M9 7h10M9 12h10M9 17h10" />
+    <path d="m4 7 1.2 1.2L7.5 6M4 12l1.2 1.2L7.5 11M4 17l1.2 1.2L7.5 16" />
+  </svg>
+)
+
+export const IconChart = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <path d="M4 20V8M10 20V4M16 20v-7M22 20V11" />
+  </svg>
+)

--- a/src/web/src/styles/globals.css
+++ b/src/web/src/styles/globals.css
@@ -1,43 +1,44 @@
-﻿@import "tailwindcss";
+﻿@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap');
+@import "tailwindcss";
 
 :root {
-  --surface-0: #f4f7f5;
-  --surface-1: #ffffff;
-  --surface-2: #eef3ef;
-  --surface-3: #dde7e1;
-  --surface-accent: rgba(15, 159, 110, 0.16);
-  --text-strong: #0f1f17;
-  --text: #1f3328;
-  --text-muted: #5d7468;
-  --border: #cfddd4;
-  --border-muted: #e2ebe5;
-  --border-strong: #8ea99a;
-  --accent: #0f9f6e;
-  --accent-hover: #0c835a;
-  --accent-contrast: #f4fffa;
-  --accent-soft: rgba(15, 159, 110, 0.2);
-  --accent-text: #0f7a56;
-  --card-shadow: 0 14px 35px rgba(18, 61, 43, 0.12);
+  --surface-0: #faf6ff;
+  --surface-1: rgba(255, 255, 255, 0.88);
+  --surface-2: #f3ebff;
+  --surface-3: #e5d8ff;
+  --surface-accent: rgba(244, 201, 255, 0.45);
+  --text-strong: #2f2445;
+  --text: #4a3f61;
+  --text-muted: #7f7399;
+  --border: rgba(205, 189, 236, 0.82);
+  --border-muted: rgba(229, 218, 248, 0.75);
+  --border-strong: #b4a0de;
+  --accent: #a674f9;
+  --accent-hover: #935ce8;
+  --accent-contrast: #fff9ff;
+  --accent-soft: rgba(166, 116, 249, 0.18);
+  --accent-text: #7444c6;
+  --card-shadow: 0 20px 40px rgba(164, 128, 217, 0.2);
 }
 
 :root[data-theme='dark'] {
-  --surface-0: #0b1511;
-  --surface-1: #12201a;
-  --surface-2: #182a23;
-  --surface-3: #213931;
-  --surface-accent: rgba(45, 212, 153, 0.22);
-  --text-strong: #e7f5ee;
-  --text: #cae3d8;
-  --text-muted: #8fb0a1;
-  --border: #2c4a3d;
-  --border-muted: #213c31;
-  --border-strong: #4e7462;
-  --accent: #2dd499;
-  --accent-hover: #1cb17d;
-  --accent-contrast: #042216;
-  --accent-soft: rgba(45, 212, 153, 0.24);
-  --accent-text: #88f0c8;
-  --card-shadow: 0 14px 35px rgba(1, 12, 8, 0.45);
+  --surface-0: #1a1427;
+  --surface-1: rgba(37, 30, 54, 0.88);
+  --surface-2: #2b2141;
+  --surface-3: #3d2f5d;
+  --surface-accent: rgba(144, 120, 255, 0.28);
+  --text-strong: #f6edff;
+  --text: #dccdf7;
+  --text-muted: #b6a5d7;
+  --border: rgba(97, 80, 135, 0.78);
+  --border-muted: rgba(70, 57, 104, 0.8);
+  --border-strong: #8f76c9;
+  --accent: #c39bff;
+  --accent-hover: #b086f6;
+  --accent-contrast: #25173f;
+  --accent-soft: rgba(195, 155, 255, 0.22);
+  --accent-text: #eddcff;
+  --card-shadow: 0 24px 50px rgba(10, 5, 23, 0.45);
 }
 
 @layer base {
@@ -47,9 +48,13 @@
 
   body {
     background-color: var(--surface-0);
-    background-image: radial-gradient(circle at top right, var(--surface-accent), transparent 50%);
+    background-image:
+      radial-gradient(circle at 15% 0%, rgba(252, 224, 255, 0.75), transparent 36%),
+      radial-gradient(circle at 100% 0%, var(--surface-accent), transparent 42%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.35) 0%, transparent 48%);
     color: var(--text);
-    font-family: "Plus Jakarta Sans", "Manrope", "Segoe UI", sans-serif;
+    font-family: 'Outfit', 'Plus Jakarta Sans', 'Manrope', 'Segoe UI', sans-serif;
+    letter-spacing: 0.01em;
   }
 
   *:focus-visible {
@@ -63,8 +68,11 @@
     }
 
     body {
-      background: radial-gradient(circle at top, #581c87 0%, #2e1065 38%, #0f0224 100%);
-      color: #ede9fe;
+      background:
+        radial-gradient(circle at 25% 0%, rgba(172, 124, 255, 0.24), transparent 28%),
+        radial-gradient(circle at top right, rgba(103, 198, 255, 0.2), transparent 38%),
+        linear-gradient(180deg, #120d1d 0%, #1a1329 44%, #1f1630 100%);
+      color: var(--text);
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Refresh the app visual system to a modern, minimal and highly attractive pastel aesthetic with softer surfaces, glass-like accents and a cleaner typeface.  
- Improve consistency and affordances across shared primitives (buttons, cards, inputs, badges) to make the interface feel more polished and pleasant.  
- Remove reliance on an external icon package by providing a small local SVG icon set to ensure predictable builds in restricted environments.

### Description
- Reworked global styles in `src/web/src/styles/globals.css` to introduce the `Outfit` font, a pastel color palette, updated CSS variables for light/dark themes, layered backgrounds and subtle glassmorphism effects.  
- Restyled core primitives: `Button`, `Card`, `Input`, `Select`, `Textarea`, and `Badge` under `src/web/src/shared/components/` to use rounded shapes, softer shadows, consistent paddings and accessible focus rings.  
- Updated shell and navigation: `AppShell.tsx`, `TopBar.tsx` and `BottomNav.tsx` now include refined spacing, a theme toggle with icon, a small “Focus mode” pill, and an improved bottom navigation layout with icons.  
- Added a local reusable icon set `src/web/src/shared/components/icons.tsx` and wired these icons into `TopBar`, `BottomNav` and `AppShell` to avoid adding external dependencies when the registry is unavailable.

### Testing
- Ran `npm run lint` in `src/web` and lint completed successfully.  
- Attempted `npm run build` in `src/web` and the build failed in this environment due to missing external dependencies/types (e.g. `react-router-dom`, `firebase`), so type-check/build errors are unrelated to the UI changes.  
- Started the dev server (`npm run dev`) to visually verify changes; Vite started but reported unresolved imports for external deps and an overlay appeared for missing modules, and a full-page screenshot was captured to validate the UI layout locally (`artifacts/ui-redesign.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f53001490832194717a8890f66a26)