### PR TITLE
Normalize workout inputs, add set removal & clear-on-focus, and sanitize Firestore upserts

### DIFF
--- a/src/web/src/firebase/firestore.ts
+++ b/src/web/src/firebase/firestore.ts
@@ -92,18 +92,24 @@ const upsertOwnedDoc = async (
   const snapshot = await getDoc(reference);
 
   if (snapshot.exists()) {
-    await updateDoc(reference, {
-      ...stripUndefined(payload),
-      ...stampForUpdate(),
-    });
+    await updateDoc(
+      reference,
+      stripUndefined({
+        ...payload,
+        ...stampForUpdate(),
+      }),
+    );
     return;
   }
 
-  await setDoc(reference, {
-    ownerUid: uid,
-    ...stripUndefined(payload),
-    ...stampForCreate(),
-  });
+  await setDoc(
+    reference,
+    stripUndefined({
+      ownerUid: uid,
+      ...payload,
+      ...stampForCreate(),
+    }),
+  );
 };
 
 const exercisesCol = (uid: string) => collection(db, 'users', uid, 'exercises');


### PR DESCRIPTION
### Motivation
- Improve the workout logging UX by making numeric inputs behave predictably (integer vs decimal), hide default placeholders until touched, and allow removing sets. 
- Ensure payloads sent to Firestore do not contain `undefined` fields by sanitizing upsert payloads before calling the SDK. 

### Description
- Change default set fields to empty strings and update `mapDraftToExercise` to only show numeric defaults when values are meaningful. 
- Add `toIntegerText` and `toDecimalText` normalizers and use them in `updateSet` to normalize `reps`, `rir` and decimal `kg` input; also propagate first-set `kg` to subsequent empty sets. 
- Add `clearSetDefaultOnFocus` to clear placeholder defaults on focus, and implement `removeSet` with a delete button and UI column layout adjustments. 
- Mark session as having overrides (`setHasOverrides(true)`) when adding/removing/changing sets and exercises. 
- Update `upsertOwnedDoc` in Firestore helpers to call `stripUndefined` on the final object passed to `updateDoc`/`setDoc` to avoid sending `undefined` values. 

### Testing
- Ran the frontend typecheck and build with `yarn build`, which completed successfully. 
- Ran the unit test suite with `yarn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f67088d9c83219ae92466ea6cf765)