### PR TITLE
feat(#13): show routine target sets & reps in workout log

### DIFF
--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../app/providers/useAuth'
-import { Alert, AppShell, Button, EmptyState } from '../../shared/components'
+import { Alert, AppShell, Badge, Button, EmptyState } from '../../shared/components'
 import { cn } from '../../shared/lib/cn'
 import {
   getExerciseHistoryForWorkout,
@@ -29,6 +29,9 @@ type WorkoutExercise = {
   collapsed: boolean
   sets: WorkoutSet[]
   availableMachines: Array<{ id: string; label: string }>
+  targetRepsMin?: number
+  targetRepsMax?: number
+  targetSets?: number
 }
 
 const toId = (): string =>
@@ -70,6 +73,9 @@ const mapDraftToExercise = (item: WorkoutDraft['exercises'][number]): WorkoutExe
     name: item.nameSnapshot,
     collapsed: true,
     availableMachines: item.availableMachines,
+    targetRepsMin: item.targetRepsMin,
+    targetRepsMax: item.targetRepsMax,
+    targetSets: item.targetSets,
     sets: item.sets.length > 0
       ? item.sets.map((set) => ({
           id: set.id,
@@ -104,6 +110,19 @@ const getCollapsedSummary = (exercise: WorkoutExercise): string => {
   if (primaryReps) parts.push(`${primaryReps} reps`)
   if (primaryKg) parts.push(`${primaryKg}kg`)
   return parts.join(' · ')
+}
+
+const formatTarget = (exercise: WorkoutExercise): string | null => {
+  const { targetSets, targetRepsMin, targetRepsMax } = exercise
+  if (!targetSets && !targetRepsMin) return null
+  const setsLabel = targetSets ? `${targetSets} x ` : ''
+  if (targetRepsMin && targetRepsMax && targetRepsMin !== targetRepsMax) {
+    return `${setsLabel}${targetRepsMin}-${targetRepsMax} reps`
+  }
+  if (targetRepsMin) {
+    return `${setsLabel}${targetRepsMin} reps`
+  }
+  return `${targetSets} sets`
 }
 
 // ─── Icons ────────────────────────────────────────────────────────────────────
@@ -215,6 +234,7 @@ const ExerciseCard = ({
   onDrop,
 }: ExerciseCardProps) => {
   const activeMachineId = exercise.sets[0]?.machineId
+  const targetLabel = formatTarget(exercise)
 
   return (
     <div
@@ -253,6 +273,11 @@ const ExerciseCard = ({
             <p className="mt-0.5 text-[11px] font-medium text-[var(--text-muted)]">
               {getCollapsedSummary(exercise)}
             </p>
+          )}
+          {targetLabel && (
+            <Badge className="mt-1 self-start" tone="info">
+              Target: {targetLabel}
+            </Badge>
           )}
         </button>
 

--- a/src/web/src/features/workout/workout.data.ts
+++ b/src/web/src/features/workout/workout.data.ts
@@ -84,10 +84,10 @@ const getDateKey = (date: Date): DateIso => {
   return `${year}-${month}-${day}` as DateIso
 }
 
-const toDefaultSet = (order: number): WorkoutDraftSet => ({
+const toDefaultSet = (order: number, repsHint?: number): WorkoutDraftSet => ({
   id: `set-${order + 1}`,
   order,
-  reps: 1,
+  reps: repsHint ?? 1,
   weightKg: 0,
   rpe: 1,
 })
@@ -219,7 +219,7 @@ export const getTodayWorkoutDraft = async (
         targetRepsMin: item.targetRepsMin,
         targetRepsMax: item.targetRepsMax,
         targetSets,
-        sets: Array.from({ length: targetSets }, (_, index) => toDefaultSet(index)),
+        sets: Array.from({ length: targetSets }, (_, index) => toDefaultSet(index, item.targetRepsMin)),
         availableMachines,
       }
     }),
@@ -271,7 +271,7 @@ export const getRoutineDayTemplateDraft = async (
         targetRepsMin: item.targetRepsMin,
         targetRepsMax: item.targetRepsMax,
         targetSets,
-        sets: Array.from({ length: targetSets }, (_, index) => toDefaultSet(index)),
+        sets: Array.from({ length: targetSets }, (_, index) => toDefaultSet(index, item.targetRepsMin)),
         availableMachines,
       }
     }),


### PR DESCRIPTION
## Summary
- When starting a workout from a routine, exercise cards now display a **Target badge** (e.g. `Target: 3 x 8-12 reps`) so users know their programmed sets/reps at a glance
- Pre-populated sets now use `targetRepsMin` as the default reps value instead of always hardcoding `1`
- The fix is entirely within two files — no Firestore schema changes, no migration needed

## Changes
- `workout.data.ts`: Extended `toDefaultSet()` to accept `repsHint?: number` parameter; updated both `getTodayWorkoutDraft()` and `getRoutineDayTemplateDraft()` callers to pass `item.targetRepsMin`
- `LogWorkoutPage.tsx`: Added `targetRepsMin/Max/Sets` to `WorkoutExercise` type; updated `mapDraftToExercise()` to carry those fields; added `formatTarget()` helper; rendered `<Badge tone="info">` inside `ExerciseCard` when target data is present

## Acceptance criteria
- [ ] When a workout is loaded from a routine, each exercise card whose routine entry has at least one of `targetRepsMin` / `targetSets` shows a badge formatted as "Target: N x M-P reps" (or the appropriate subset variant).
- [ ] Pre-populated sets use `targetRepsMin` as the default reps value instead of `1`. Verified by observing pre-filled reps inputs after loading a routine that has `targetRepsMin > 1`.
- [ ] Works for fresh sessions: loading `/app/workout/log?dayId=<id>` for a day that has never been logged shows targets and correct pre-filled reps.
- [ ] Works for resumed sessions: re-opening a workout logged today still shows the target badge.
- [ ] Ad-hoc exercises (added via the exercise picker, not from routine) display no target badge and suffer no regression.
- [ ] No TypeScript errors con `strict: true`. `npm run build` ✅
- [ ] `npm run lint` passes con no new warnings.

## References
Implements `solutions/13-show-routine-target-sets-reps-workout-log.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)