### PR TITLE
feat(#16): inline rename on double-click, remove Day Names section

### DIFF
--- a/src/web/src/features/routines/RoutineBuilderPage.tsx
+++ b/src/web/src/features/routines/RoutineBuilderPage.tsx
@@ -43,6 +43,7 @@ export const RoutineBuilderPage = () => {
   const [days, setDays] = useState<RoutineDayWithExercises[]>([])
   const [activeDayId, setActiveDayId] = useState('')
   const [dayNameDrafts, setDayNameDrafts] = useState<Record<string, string>>({})
+  const [editingDayId, setEditingDayId] = useState<string | null>(null)
   const [draggingExerciseId, setDraggingExerciseId] = useState<string | null>(null)
   const [exerciseSearch, setExerciseSearch] = useState('')
   const [availableExercises, setAvailableExercises] = useState<Array<WithId<Exercise>>>([])
@@ -238,40 +239,48 @@ export const RoutineBuilderPage = () => {
 
       <Card className="space-y-3">
         <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-[var(--text-muted)]">
-          Day Names
-        </h2>
-        <div className="grid gap-2 md:grid-cols-2">
-          {days.map((day, index) => (
-            <Input
-              id={`day-name-${day.id}`}
-              key={day.id}
-              label={`Day ${index + 1}`}
-              onBlur={() => void onRenameDay(day.id)}
-              onChange={(event) =>
-                setDayNameDrafts((prev) => ({ ...prev, [day.id]: event.target.value }))
-              }
-              placeholder={`Day ${index + 1}`}
-              value={dayNameDrafts[day.id] ?? ''}
-            />
-          ))}
-        </div>
-      </Card>
-
-      <Card className="space-y-3">
-        <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-[var(--text-muted)]">
           Weekly Days
         </h2>
         <div className="flex flex-wrap gap-2">
-          {days.map((day) => (
-            <Button
-              key={day.id}
-              onClick={() => setActiveDayId(day.id)}
-              size="sm"
-              variant={selectedDay?.id === day.id ? 'primary' : 'secondary'}
-            >
-              {day.label || 'Unnamed day'}
-            </Button>
-          ))}
+          {days.map((day) =>
+            editingDayId === day.id ? (
+              <input
+                key={day.id}
+                autoFocus
+                className="h-10 rounded-2xl border border-[var(--border)] bg-[var(--surface-1)] px-3.5 text-sm font-semibold text-[var(--text-strong)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+                onBlur={() => {
+                  void onRenameDay(day.id)
+                  setEditingDayId(null)
+                }}
+                onChange={(event) =>
+                  setDayNameDrafts((prev) => ({ ...prev, [day.id]: event.target.value }))
+                }
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    void onRenameDay(day.id)
+                    setEditingDayId(null)
+                  }
+                  if (event.key === 'Escape') {
+                    setEditingDayId(null)
+                  }
+                }}
+                value={dayNameDrafts[day.id] ?? ''}
+              />
+            ) : (
+              <Button
+                key={day.id}
+                onClick={() => setActiveDayId(day.id)}
+                onDoubleClick={() => {
+                  setActiveDayId(day.id)
+                  setEditingDayId(day.id)
+                }}
+                size="sm"
+                variant={selectedDay?.id === day.id ? 'primary' : 'secondary'}
+              >
+                {day.label || 'Unnamed day'}
+              </Button>
+            ),
+          )}
         </div>
       </Card>
 


### PR DESCRIPTION
## Summary
- La sección "Day Names" duplicaba visualmente la información de los chips de "Weekly Days"
- Renombrar un día requería bajar hasta la card separada en lugar de hacerlo directamente en el chip
- Se elimina la card redundante y se mueve el rename a un input inline contextual al chip

## Changes
- `features/routines/RoutineBuilderPage.tsx` — eliminar bloque `<Card>` "Day Names"; añadir `editingDayId` state; chips de "Weekly Days" soportan `onDoubleClick` para entrar en modo edición inline; `Enter`/`blur` guarda, `Escape` cancela

## Acceptance criteria
- [ ] La sección "Day Names" ya no aparece en el routine builder
- [ ] Double-click en un chip de "Weekly Days" activa un input inline editable
- [ ] Confirmar con `Enter` o `blur` guarda el nuevo nombre en Firestore
- [ ] `Escape` cancela la edición sin guardar
- [ ] Single-click en el chip sigue seleccionando el día (comportamiento existente)
- [ ] El label del chip se actualiza visualmente tras guardar sin reload
- [ ] TypeScript strict mode pasa sin errores
- [ ] Funciona en viewport mobile

## References
Implements `solutions/16-remove-day-names-inline-rename.md`
Closes #16

🤖 Generated with [Claude Code](https://claude.ai/claude-code)