### PR TITLE
fix(#19): keep user on log page with Finish Workout button

### DIFF
--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../app/providers/useAuth'
 import { Alert, AppShell, Badge, Button, EmptyState } from '../../shared/components'
 import { cn } from '../../shared/lib/cn'
 import {
+  finishWorkout,
   getExerciseHistoryForWorkout,
   getExerciseMachines,
   getRoutineDayTemplateDraft,
@@ -434,10 +435,14 @@ export const LogWorkoutPage = () => {
   const [draggingExerciseId, setDraggingExerciseId] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
+  const [isSaved, setIsSaved] = useState(false)
+  const [savedItemsSnapshot, setSavedItemsSnapshot] = useState<string | null>(null)
   const [hasOverrides, setHasOverrides] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [defaultExerciseNames, setDefaultExerciseNames] = useState<string[]>([])
   const [exerciseHistories, setExerciseHistories] = useState<Record<string, ExerciseHistory | 'loading' | null>>({})
+
+  const hasChanges = savedItemsSnapshot === null || JSON.stringify(items) !== savedItemsSnapshot
 
   useEffect(() => {
     const load = async () => {
@@ -685,9 +690,24 @@ export const LogWorkoutPage = () => {
         })),
       })
 
-      navigate('/app/workout')
+      setIsSaved(true)
+      setSavedItemsSnapshot(JSON.stringify(items))
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : 'Unable to save workout.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const onFinish = async () => {
+    if (!user || !context) return
+    setIsSaving(true)
+    setError(null)
+    try {
+      await finishWorkout(user.uid, context.dateKey)
+      navigate('/app/workout')
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Unable to finish workout.')
     } finally {
       setIsSaving(false)
     }
@@ -808,19 +828,33 @@ export const LogWorkoutPage = () => {
         />
       ))}
 
-      {/* ── Save button ────────────────────────────────────────────────────── */}
+      {/* ── Save / Finish button ───────────────────────────────────────────── */}
       <div className="sticky bottom-20 z-10 pt-2">
-        <button
-          className="flex w-full items-center justify-center gap-2 rounded-2xl bg-[var(--accent)] py-3.5 text-[15px] font-bold text-white shadow-[0_8px_24px_rgba(124,58,237,0.4)] transition-all duration-200 hover:bg-[var(--accent-hover)] hover:shadow-[0_12px_32px_rgba(124,58,237,0.5)] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
-          disabled={isSaving}
-          onClick={() => void onSave()}
-          type="button"
-        >
-          {isSaving ? (
-            <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-r-transparent" />
-          ) : null}
-          {isSaving ? 'Saving…' : 'Save Workout'}
-        </button>
+        {isSaved && !hasChanges ? (
+          <button
+            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-[var(--accent)] py-3.5 text-[15px] font-bold text-white shadow-[0_8px_24px_rgba(124,58,237,0.4)] transition-all duration-200 hover:bg-[var(--accent-hover)] hover:shadow-[0_12px_32px_rgba(124,58,237,0.5)] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isSaving}
+            onClick={() => void onFinish()}
+            type="button"
+          >
+            {isSaving ? (
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-r-transparent" />
+            ) : null}
+            {isSaving ? 'Finishing…' : 'Finish Workout'}
+          </button>
+        ) : (
+          <button
+            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-[var(--accent)] py-3.5 text-[15px] font-bold text-white shadow-[0_8px_24px_rgba(124,58,237,0.4)] transition-all duration-200 hover:bg-[var(--accent-hover)] hover:shadow-[0_12px_32px_rgba(124,58,237,0.5)] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isSaving}
+            onClick={() => void onSave()}
+            type="button"
+          >
+            {isSaving ? (
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-r-transparent" />
+            ) : null}
+            {isSaving ? 'Saving…' : 'Save Workout'}
+          </button>
+        )}
       </div>
     </AppShell>
   )

--- a/src/web/src/features/workout/workout.data.ts
+++ b/src/web/src/features/workout/workout.data.ts
@@ -352,7 +352,13 @@ export const saveWorkout = async (uid: string, payload: SaveWorkoutInput): Promi
     }
   }
 
-  await workoutStore.finish(uid, sessionId)
+}
+
+export const finishWorkout = async (uid: string, dateKey: DateIso): Promise<void> => {
+  if (!DATE_KEY_PATTERN.test(dateKey)) {
+    throw new Error('Date key must be YYYY-MM-DD.')
+  }
+  await workoutStore.finish(uid, dateKey)
 }
 
 export const getExerciseHistoryForWorkout = async (


### PR DESCRIPTION
## Summary
- Al guardar workout, el usuario permanece en `/app/workout/log` en lugar de ser redirigido
- El botón sticky cambia a "Finish Workout" cuando no hay cambios pendientes tras guardar
- `endedAt` en Firestore solo se escribe al presionar "Finish Workout", no en saves intermedios
- Al hacer cualquier modificación tras un save, el botón regresa a "Save Workout"

## Changes
- `workout.data.ts`: Removido `workoutStore.finish()` de `saveWorkout`; nueva función exportada `finishWorkout(uid, dateKey)`
- `LogWorkoutPage.tsx`: Nuevos estados `isSaved` + `savedItemsSnapshot`; valor derivado `hasChanges`; handler `onFinish`; botón sticky con renderizado condicional Save/Finish

## Acceptance criteria
- [x] Al guardar, el usuario permanece en `/app/workout/log`
- [x] El botón cambia a "Finish Workout" si no hay cambios pendientes tras guardar
- [x] Al hacer cualquier modificación tras un save, el botón regresa a "Save Workout"
- [x] Presionar "Finish Workout" navega al dashboard (`/app/workout`)
- [x] `endedAt` en Firestore solo se escribe al presionar "Finish Workout", no en saves intermedios
- [x] TypeScript strict mode passes (sin `any`, tipos correctos en `finishWorkout`)

## References
Implements `solutions/19-save-workout-finish-button.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)