### PR TITLE
fix(#21): show full reps range in collapsed exercise summary

### DIFF
--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -106,8 +106,15 @@ const getCollapsedSummary = (exercise: WorkoutExercise): string => {
   const count = exercise.sets.length
   const primaryKg = exercise.sets.find((s) => s.kg)?.kg
   const primaryReps = exercise.sets.find((s) => s.reps)?.reps
+  const { targetRepsMin, targetRepsMax } = exercise
+  const repsDisplay =
+    targetRepsMin != null && targetRepsMax != null
+      ? targetRepsMin === targetRepsMax
+        ? `${targetRepsMin}`
+        : `${targetRepsMin}-${targetRepsMax}`
+      : primaryReps
   const parts: string[] = [`${count} ${count === 1 ? 'set' : 'sets'}`]
-  if (primaryReps) parts.push(`${primaryReps} reps`)
+  if (repsDisplay) parts.push(`${repsDisplay} reps`)
   if (primaryKg) parts.push(`${primaryKg}kg`)
   return parts.join(' · ')
 }


### PR DESCRIPTION
## Summary
- El resumen colapsado de ejercicio ahora muestra el rango completo de reps (e.g., "8-12 reps")
- Cuando min === max, muestra valor único (e.g., "10 reps")
- Ejercicios ad-hoc sin target definido mantienen el comportamiento anterior

## Changes
- `LogWorkoutPage.tsx`: `getCollapsedSummary` ahora deriva `repsDisplay` de `targetRepsMin`/`targetRepsMax` con fallback a `primaryReps`

## Acceptance criteria
- [x] Cuando `minReps !== maxReps`, muestra rango (e.g., `8-12 reps`)
- [x] Cuando `minReps === maxReps`, muestra valor único (e.g., `10 reps`)
- [x] Ejercicios ad-hoc (sin target definido) mantienen el comportamiento anterior
- [x] TypeScript strict mode passes

## References
Implements `solutions/21-collapsed-exercise-min-reps-only.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)