### PR TITLE
feat(#22): linked exercises with A/B alternative selection in workout

### DIFF
--- a/docs/FirestoreSchema.md
+++ b/docs/FirestoreSchema.md
@@ -67,6 +67,7 @@ Suggested fields:
 - `targetRepsMax: number`
 - `targetSets: number`
 - `order: number`
+- `linkedExerciseItemId: string?` (id of the sibling exercise item that acts as an alternative; bidirectional — both items point to each other)
 - `createdAt: timestamp`
 - `updatedAt: timestamp`
 

--- a/src/web/src/features/routines/RoutineBuilderPage.tsx
+++ b/src/web/src/features/routines/RoutineBuilderPage.tsx
@@ -15,8 +15,10 @@ import {
 import { listExercises } from '../exercises/exercises.data'
 import {
   getRoutineBuilderData,
+  linkExercisesInDay,
   renameRoutineDay,
   replaceDayExercises,
+  unlinkExercisesInDay,
   type RoutineDayWithExercises,
 } from './routines.data'
 
@@ -52,6 +54,7 @@ export const RoutineBuilderPage = () => {
   const [targetRepsMin, setTargetRepsMin] = useState('8')
   const [targetRepsMax, setTargetRepsMax] = useState('12')
   const [targetSets, setTargetSets] = useState('3')
+  const [linkPickerForItemId, setLinkPickerForItemId] = useState<string | null>(null)
 
   const refreshRoutineData = async () => {
     if (!user || !routineId) {
@@ -182,6 +185,7 @@ export const RoutineBuilderPage = () => {
         targetRepsMin: item.targetRepsMin ?? 8,
         targetRepsMax: item.targetRepsMax ?? 12,
         targetSets: item.targetSets ?? 3,
+        linkedExerciseItemId: item.linkedExerciseItemId,
       })),
       {
         itemId: toItemId(),
@@ -195,6 +199,35 @@ export const RoutineBuilderPage = () => {
 
     setAddModalOpen(false)
     setPendingExercise(null)
+  }
+
+  const onLinkExercise = async (itemId: string, targetItemId: string) => {
+    if (!user || !routineId || !selectedDay) return
+    try {
+      setIsSaving(true)
+      setError(null)
+      await linkExercisesInDay(user.uid, routineId, selectedDay.id, itemId, targetItemId)
+      await refreshRoutineData()
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Unable to link exercises.')
+    } finally {
+      setIsSaving(false)
+      setLinkPickerForItemId(null)
+    }
+  }
+
+  const onUnlinkExercise = async (itemId: string, linkedItemId: string) => {
+    if (!user || !routineId || !selectedDay) return
+    try {
+      setIsSaving(true)
+      setError(null)
+      await unlinkExercisesInDay(user.uid, routineId, selectedDay.id, itemId, linkedItemId)
+      await refreshRoutineData()
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Unable to unlink exercises.')
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   if (!routineId || !user) {
@@ -385,6 +418,7 @@ export const RoutineBuilderPage = () => {
                             targetRepsMin: item.targetRepsMin ?? 8,
                             targetRepsMax: item.targetRepsMax ?? 12,
                             targetSets: item.targetSets ?? 3,
+                            linkedExerciseItemId: item.linkedExerciseItemId,
                           })),
                         )
                         setDraggingExerciseId(null)
@@ -398,29 +432,106 @@ export const RoutineBuilderPage = () => {
                           <p className="text-xs text-[var(--text-muted)]">
                             Target: {exercise.targetRepsMin ?? 8}-{exercise.targetRepsMax ?? 12} reps x {exercise.targetSets ?? 3} sets
                           </p>
+                          {exercise.linkedExerciseItemId && (
+                            <p className="text-xs text-[var(--accent-text)]">
+                              Linked alt: {selectedDay.exercises.find((e) => e.id === exercise.linkedExerciseItemId)?.nameSnapshot ?? '—'}
+                            </p>
+                          )}
                         </div>
-                        <Button
-                          onClick={() =>
-                            void persistDayExercises(
-                              selectedDay.id,
-                              selectedDay.exercises
-                                .filter((item) => item.id !== exercise.id)
-                                .map((item) => ({
-                                  itemId: item.id,
-                                  exerciseId: item.exerciseId,
-                                  nameSnapshot: item.nameSnapshot,
-                                  targetRepsMin: item.targetRepsMin ?? 8,
-                                  targetRepsMax: item.targetRepsMax ?? 12,
-                                  targetSets: item.targetSets ?? 3,
-                                })),
-                            )
-                          }
-                          size="sm"
-                          variant="ghost"
-                        >
-                          Remove
-                        </Button>
+                        <div className="flex items-center gap-1">
+                          {exercise.linkedExerciseItemId ? (
+                            <Button
+                              onClick={() =>
+                                void onUnlinkExercise(exercise.id, exercise.linkedExerciseItemId!)
+                              }
+                              size="sm"
+                              variant="ghost"
+                            >
+                              Unlink
+                            </Button>
+                          ) : (
+                            <Button
+                              onClick={() =>
+                                setLinkPickerForItemId((prev) =>
+                                  prev === exercise.id ? null : exercise.id,
+                                )
+                              }
+                              size="sm"
+                              variant="ghost"
+                            >
+                              Link alt
+                            </Button>
+                          )}
+                          <Button
+                            onClick={async () => {
+                              if (exercise.linkedExerciseItemId) {
+                                await onUnlinkExercise(exercise.id, exercise.linkedExerciseItemId)
+                              }
+                              void persistDayExercises(
+                                selectedDay.id,
+                                selectedDay.exercises
+                                  .filter((item) => item.id !== exercise.id)
+                                  .map((item) => ({
+                                    itemId: item.id,
+                                    exerciseId: item.exerciseId,
+                                    nameSnapshot: item.nameSnapshot,
+                                    targetRepsMin: item.targetRepsMin ?? 8,
+                                    targetRepsMax: item.targetRepsMax ?? 12,
+                                    targetSets: item.targetSets ?? 3,
+                                    linkedExerciseItemId:
+                                      item.linkedExerciseItemId === exercise.id
+                                        ? undefined
+                                        : item.linkedExerciseItemId,
+                                  })),
+                              )
+                            }}
+                            size="sm"
+                            variant="ghost"
+                          >
+                            Remove
+                          </Button>
+                        </div>
                       </div>
+
+                      {linkPickerForItemId === exercise.id && (
+                        <div className="mt-2 rounded-xl border border-[var(--border)] bg-[var(--surface-1)] p-3 space-y-2">
+                          <p className="text-xs font-semibold text-[var(--text-muted)]">
+                            Select an exercise to link as alternative:
+                          </p>
+                          {selectedDay.exercises
+                            .filter(
+                              (other) =>
+                                other.id !== exercise.id &&
+                                !other.linkedExerciseItemId,
+                            )
+                            .map((other) => (
+                              <button
+                                className="flex w-full items-center justify-between rounded-lg border border-[var(--border-muted)] bg-[var(--surface-2)] px-3 py-2 text-left text-sm font-medium text-[var(--text-strong)] transition hover:border-[var(--accent)] hover:bg-[var(--accent-soft)]"
+                                key={other.id}
+                                onClick={() => void onLinkExercise(exercise.id, other.id)}
+                                type="button"
+                              >
+                                {other.nameSnapshot}
+                              </button>
+                            ))}
+                          {selectedDay.exercises.filter(
+                            (other) =>
+                              other.id !== exercise.id &&
+                              !other.linkedExerciseItemId,
+                          ).length === 0 && (
+                            <p className="text-xs text-[var(--text-muted)]">
+                              No available exercises to link.
+                            </p>
+                          )}
+                          <Button
+                            onClick={() => setLinkPickerForItemId(null)}
+                            size="sm"
+                            variant="secondary"
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/src/web/src/features/routines/routines.data.ts
+++ b/src/web/src/features/routines/routines.data.ts
@@ -223,6 +223,7 @@ export const replaceDayExercises = async (
     targetRepsMin: number
     targetRepsMax: number
     targetSets: number
+    linkedExerciseItemId?: string
   }>,
 ): Promise<void> => {
   const previous = await routineStore.listDayExercises(uid, routineId, dayId)
@@ -235,6 +236,7 @@ export const replaceDayExercises = async (
     targetRepsMin: item.targetRepsMin,
     targetRepsMax: item.targetRepsMax,
     targetSets: item.targetSets,
+    linkedExerciseItemId: item.linkedExerciseItemId,
   }))
 
   await Promise.all(
@@ -246,6 +248,7 @@ export const replaceDayExercises = async (
         targetRepsMax: item.targetRepsMax,
         targetSets: item.targetSets,
         order: index,
+        linkedExerciseItemId: item.linkedExerciseItemId,
       }),
     ),
   )
@@ -262,4 +265,24 @@ export const replaceDayExercises = async (
     order: currentDay?.order ?? 0,
     exerciseOrder: nextWithIds.map((item) => item.itemId),
   })
+}
+
+export const linkExercisesInDay = async (
+  uid: string,
+  routineId: string,
+  dayId: string,
+  itemIdA: string,
+  itemIdB: string,
+): Promise<void> => {
+  await routineStore.linkDayExercises(uid, routineId, dayId, itemIdA, itemIdB)
+}
+
+export const unlinkExercisesInDay = async (
+  uid: string,
+  routineId: string,
+  dayId: string,
+  itemIdA: string,
+  itemIdB: string,
+): Promise<void> => {
+  await routineStore.unlinkDayExercises(uid, routineId, dayId, itemIdA, itemIdB)
 }

--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -32,6 +32,11 @@ type WorkoutExercise = {
   targetRepsMin?: number
   targetRepsMax?: number
   targetSets?: number
+  linkedExerciseItemId?: string
+  linkedExerciseId?: string
+  linkedName?: string
+  linkedAvailableMachines?: Array<{ id: string; label: string }>
+  selectedAlternative: 'A' | 'B'
 }
 
 const toId = (): string =>
@@ -76,6 +81,11 @@ const mapDraftToExercise = (item: WorkoutDraft['exercises'][number]): WorkoutExe
     targetRepsMin: item.targetRepsMin,
     targetRepsMax: item.targetRepsMax,
     targetSets: item.targetSets,
+    linkedExerciseItemId: item.linkedExerciseItemId,
+    linkedExerciseId: item.linkedExerciseId,
+    linkedName: item.linkedNameSnapshot,
+    linkedAvailableMachines: item.linkedAvailableMachines,
+    selectedAlternative: 'A',
     sets: item.sets.length > 0
       ? item.sets.map((set) => ({
           id: set.id,
@@ -215,6 +225,9 @@ type ExerciseCardProps = {
   onDragStart: () => void
   onDragOver: (e: React.DragEvent) => void
   onDrop: () => void
+  onSwitchAlternative?: () => void
+  linkedName?: string
+  selectedAlternative?: 'A' | 'B'
 }
 
 const ExerciseCard = ({
@@ -232,6 +245,9 @@ const ExerciseCard = ({
   onDragStart,
   onDragOver,
   onDrop,
+  onSwitchAlternative,
+  linkedName,
+  selectedAlternative,
 }: ExerciseCardProps) => {
   const activeMachineId = exercise.sets[0]?.machineId
   const targetLabel = formatTarget(exercise)
@@ -267,7 +283,7 @@ const ExerciseCard = ({
           type="button"
         >
           <p className="truncate text-[15px] font-semibold leading-tight text-[var(--text-strong)]">
-            {exercise.name}
+            {selectedAlternative === 'B' && linkedName ? linkedName : exercise.name}
           </p>
           {exercise.collapsed && (
             <p className="mt-0.5 text-[11px] font-medium text-[var(--text-muted)]">
@@ -280,6 +296,36 @@ const ExerciseCard = ({
             </Badge>
           )}
         </button>
+
+        {/* A/B toggle */}
+        {linkedName && (
+          <div className="flex items-center gap-1">
+            <button
+              className={cn(
+                'rounded-full px-3 py-0.5 text-xs font-semibold transition-all duration-150',
+                selectedAlternative === 'A'
+                  ? 'bg-[var(--accent)] text-white'
+                  : 'border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-muted)]',
+              )}
+              onClick={(e) => { e.stopPropagation(); onSwitchAlternative?.(); }}
+              type="button"
+            >
+              A
+            </button>
+            <button
+              className={cn(
+                'rounded-full px-3 py-0.5 text-xs font-semibold transition-all duration-150',
+                selectedAlternative === 'B'
+                  ? 'bg-[var(--accent)] text-white'
+                  : 'border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-muted)]',
+              )}
+              onClick={(e) => { e.stopPropagation(); onSwitchAlternative?.(); }}
+              type="button"
+            >
+              B
+            </button>
+          </div>
+        )}
 
         {/* Chevron */}
         <button
@@ -497,6 +543,16 @@ export const LogWorkoutPage = () => {
     [context, selectedExercise],
   )
 
+  const deduplicatedItems = useMemo(() => {
+    const hiddenIds = new Set<string>()
+    for (const item of items) {
+      if (item.linkedExerciseItemId && !hiddenIds.has(item.id)) {
+        hiddenIds.add(item.linkedExerciseItemId)
+      }
+    }
+    return items.filter((item) => !hiddenIds.has(item.id))
+  }, [items])
+
   const addAdHocExercise = async () => {
     if (!selectedExerciseItem || !user) {
       return
@@ -515,6 +571,7 @@ export const LogWorkoutPage = () => {
         collapsed: false,
         availableMachines,
         sets: [createSet(defaultMachine)],
+        selectedAlternative: 'A' as const,
       },
     ])
   }
@@ -657,6 +714,23 @@ export const LogWorkoutPage = () => {
     )
   }
 
+  const switchAlternative = (exerciseId: string) => {
+    setHasOverrides(true)
+    setItems((prev) =>
+      prev.map((item) => {
+        if (item.id !== exerciseId || !item.linkedExerciseItemId) return item
+        const next = item.selectedAlternative === 'A' ? 'B' : 'A'
+        const defaultMachine =
+          next === 'B' ? item.linkedAvailableMachines?.[0] : item.availableMachines[0]
+        return {
+          ...item,
+          selectedAlternative: next,
+          sets: [createSet(defaultMachine)],
+        }
+      }),
+    )
+  }
+
   const onSave = async () => {
     if (!user || !context) return
 
@@ -672,17 +746,20 @@ export const LogWorkoutPage = () => {
         routineDayLabel: context.routineDayLabel,
         isFromActiveRoutine: context.isFromActiveRoutine,
         hasSessionOverrides: hasOverrides,
-        exercises: items.map((item) => ({
-          exerciseId: item.sourceExerciseId,
-          nameSnapshot: item.name,
-          sets: item.sets.map((set) => ({
-            reps: parsePositiveNumber(set.reps, 1),
-            weightKg: parseNonNegativeNumber(set.kg),
-            rpe: parsePositiveNumber(set.rir, 1),
-            machineId: set.machineId,
-            machineLabel: set.machineLabel,
-          })),
-        })),
+        exercises: deduplicatedItems.map((item) => {
+          const useB = item.selectedAlternative === 'B' && item.linkedExerciseId !== undefined
+          return {
+            exerciseId: useB ? item.linkedExerciseId : item.sourceExerciseId,
+            nameSnapshot: useB ? (item.linkedName ?? item.name) : item.name,
+            sets: item.sets.map((set) => ({
+              reps: parsePositiveNumber(set.reps, 1),
+              weightKg: parseNonNegativeNumber(set.kg),
+              rpe: parsePositiveNumber(set.rir, 1),
+              machineId: set.machineId,
+              machineLabel: set.machineLabel,
+            })),
+          }
+        }),
       })
 
       navigate('/app/workout')
@@ -767,7 +844,7 @@ export const LogWorkoutPage = () => {
       )}
 
       {/* ── Empty state ────────────────────────────────────────────────────── */}
-      {items.length === 0 && (
+      {deduplicatedItems.length === 0 && (
         <EmptyState
           action={<Button onClick={() => void addAdHocExercise()}>Add exercise</Button>}
           description="No exercise loaded for this session."
@@ -776,7 +853,7 @@ export const LogWorkoutPage = () => {
       )}
 
       {/* ── Exercise list ──────────────────────────────────────────────────── */}
-      {items.map((exercise, index) => (
+      {deduplicatedItems.map((exercise, index) => (
         <ExerciseCard
           history={
             exercise.sourceExerciseId
@@ -805,6 +882,9 @@ export const LogWorkoutPage = () => {
             setItems((prev) => reorderItems(prev, fromIndex, toIndex))
             setDraggingExerciseId(null)
           }}
+          onSwitchAlternative={() => switchAlternative(exercise.id)}
+          linkedName={exercise.linkedName}
+          selectedAlternative={exercise.selectedAlternative}
         />
       ))}
 

--- a/src/web/src/features/workout/workout.data.ts
+++ b/src/web/src/features/workout/workout.data.ts
@@ -31,6 +31,10 @@ export type WorkoutDraftExercise = {
   targetSets?: number
   sets: WorkoutDraftSet[]
   availableMachines: Array<{ id: string; label: string }>
+  linkedExerciseItemId?: string
+  linkedExerciseId?: string
+  linkedNameSnapshot?: string
+  linkedAvailableMachines?: Array<{ id: string; label: string }>
 }
 
 export type WorkoutDraft = {
@@ -205,12 +209,17 @@ export const getTodayWorkoutDraft = async (
   const routineDayExercises = selectedDayId
     ? await routineStore.listDayExercises(uid, routine.id, selectedDayId)
     : []
+  const itemsById = new Map(routineDayExercises.map((item) => [item.id, item]))
   const draftExercises = await Promise.all(
     routineDayExercises.map(async (item) => {
       const targetSets = item.targetSets ?? 1
       const availableMachines = item.exerciseId
         ? (await exerciseMachineStore.list(uid, item.exerciseId)).map((m) => ({ id: m.id, label: m.label }))
         : []
+      const linkedItem = item.linkedExerciseItemId ? itemsById.get(item.linkedExerciseItemId) : undefined
+      const linkedAvailableMachines = linkedItem?.exerciseId
+        ? (await exerciseMachineStore.list(uid, linkedItem.exerciseId)).map((m) => ({ id: m.id, label: m.label }))
+        : undefined
       return {
         id: item.id,
         order: item.order,
@@ -221,6 +230,10 @@ export const getTodayWorkoutDraft = async (
         targetSets,
         sets: Array.from({ length: targetSets }, (_, index) => toDefaultSet(index, item.targetRepsMin)),
         availableMachines,
+        linkedExerciseItemId: item.linkedExerciseItemId,
+        linkedExerciseId: linkedItem?.exerciseId,
+        linkedNameSnapshot: linkedItem?.nameSnapshot,
+        linkedAvailableMachines,
       }
     }),
   )
@@ -257,12 +270,17 @@ export const getRoutineDayTemplateDraft = async (
   }
 
   const dayExercises = await routineStore.listDayExercises(uid, routineId, routineDayId)
+  const dayItemsById = new Map(dayExercises.map((item) => [item.id, item]))
   const exercises = await Promise.all(
     dayExercises.map(async (item) => {
       const targetSets = item.targetSets ?? 1
       const availableMachines = item.exerciseId
         ? (await exerciseMachineStore.list(uid, item.exerciseId)).map((m) => ({ id: m.id, label: m.label }))
         : []
+      const linkedItem = item.linkedExerciseItemId ? dayItemsById.get(item.linkedExerciseItemId) : undefined
+      const linkedAvailableMachines = linkedItem?.exerciseId
+        ? (await exerciseMachineStore.list(uid, linkedItem.exerciseId)).map((m) => ({ id: m.id, label: m.label }))
+        : undefined
       return {
         id: item.id,
         order: item.order,
@@ -273,6 +291,10 @@ export const getRoutineDayTemplateDraft = async (
         targetSets,
         sets: Array.from({ length: targetSets }, (_, index) => toDefaultSet(index, item.targetRepsMin)),
         availableMachines,
+        linkedExerciseItemId: item.linkedExerciseItemId,
+        linkedExerciseId: linkedItem?.exerciseId,
+        linkedNameSnapshot: linkedItem?.nameSnapshot,
+        linkedAvailableMachines,
       }
     }),
   )

--- a/src/web/src/firebase/firestore.ts
+++ b/src/web/src/firebase/firestore.ts
@@ -7,6 +7,7 @@ import {
   limit,
   orderBy,
   query,
+  runTransaction,
   serverTimestamp,
   setDoc,
   updateDoc,
@@ -334,8 +335,39 @@ export const routineStore = {
         targetRepsMax: payload.targetRepsMax,
         targetSets: payload.targetSets,
         order: payload.order,
+        linkedExerciseItemId: payload.linkedExerciseItemId ?? null,
       },
     );
+  },
+
+  async linkDayExercises(
+    uid: string,
+    routineId: string,
+    dayId: string,
+    itemIdA: string,
+    itemIdB: string,
+  ): Promise<void> {
+    const refA = doc(db, 'users', uid, 'routines', routineId, 'days', dayId, 'exercises', itemIdA)
+    const refB = doc(db, 'users', uid, 'routines', routineId, 'days', dayId, 'exercises', itemIdB)
+    await runTransaction(db, async (tx) => {
+      tx.update(refA, { linkedExerciseItemId: itemIdB, updatedAt: serverTimestamp() })
+      tx.update(refB, { linkedExerciseItemId: itemIdA, updatedAt: serverTimestamp() })
+    })
+  },
+
+  async unlinkDayExercises(
+    uid: string,
+    routineId: string,
+    dayId: string,
+    itemIdA: string,
+    itemIdB: string,
+  ): Promise<void> {
+    const refA = doc(db, 'users', uid, 'routines', routineId, 'days', dayId, 'exercises', itemIdA)
+    const refB = doc(db, 'users', uid, 'routines', routineId, 'days', dayId, 'exercises', itemIdB)
+    await runTransaction(db, async (tx) => {
+      tx.update(refA, { linkedExerciseItemId: null, updatedAt: serverTimestamp() })
+      tx.update(refB, { linkedExerciseItemId: null, updatedAt: serverTimestamp() })
+    })
   },
 
   async removeDayExercise(

--- a/src/web/src/shared/types/firestore.ts
+++ b/src/web/src/shared/types/firestore.ts
@@ -75,6 +75,7 @@ export interface RoutineDayExercise {
   targetRepsMax: number;
   targetSets: number;
   order: number;
+  linkedExerciseItemId?: string;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
@@ -86,6 +87,7 @@ export interface NewRoutineDayExerciseInput {
   targetRepsMax: number;
   targetSets: number;
   order: number;
+  linkedExerciseItemId?: string;
 }
 
 export interface WorkoutSession {


### PR DESCRIPTION
## Summary
- Dos ejercicios en un día de rutina pueden marcarse como "alternativas vinculadas"
- En workout, ejercicios vinculados se muestran como una sola tarjeta con toggle A/B
- Solo se loguean los sets del ejercicio seleccionado (A o B)
- El link es bidireccional con `runTransaction` para atomicidad garantizada

## Changes
- `firestore.ts`: `linkedExerciseItemId` en `upsertDayExercise`; nuevos métodos `linkDayExercises`/`unlinkDayExercises` con Firestore transaction
- `routines.data.ts`: `linkExercisesInDay`/`unlinkExercisesInDay` bridge; `linkedExerciseItemId` propagado en `replaceDayExercises`
- `RoutineBuilderPage.tsx`: UI de Link/Unlink alt con picker inline
- `workout.data.ts`: `WorkoutDraftExercise` con 4 campos linked; resolución por Map en `getTodayWorkoutDraft` y `getRoutineDayTemplateDraft`
- `LogWorkoutPage.tsx`: `WorkoutExercise` con `selectedAlternative`; `deduplicatedItems` useMemo; handler `switchAlternative`; toggle A/B pill en ExerciseCard; `onSave` serializa alternativa activa
- `FirestoreSchema.md`: documentado campo `linkedExerciseItemId`

## Acceptance criteria
- [x] En edición de rutina se puede linkear un ejercicio con otro del mismo día
- [x] El link es bidireccional (runTransaction garantiza ambos punteros)
- [x] Eliminar ejercicio linkeado limpia el puntero inverso
- [x] En workout, ejercicios linkeados se muestran como una sola tarjeta con selector A/B
- [x] Solo se loguean los sets del ejercicio seleccionado (A o B)
- [x] Schema docs actualizados
- [x] TypeScript strict mode passes

## References
Implements `solutions/22-linked-exercises-alternative-selection.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)