### PR TITLE
feat(#23): dropset toggle per set in workout log

### DIFF
--- a/src/web/src/features/history/HistoryPage.tsx
+++ b/src/web/src/features/history/HistoryPage.tsx
@@ -200,7 +200,8 @@ export const HistoryPage = () => {
                     .map((set) => {
                       const rirSuffix = set.rpe === undefined ? '' : ` RIR ${set.rpe}`
                       const machineSuffix = set.machineLabel ? ` [${set.machineLabel}]` : ''
-                      return `${set.reps} x ${set.weightKg}kg${rirSuffix}${machineSuffix}`
+                      const dropsetSuffix = set.isDropset ? ' ↓DS' : ''
+                      return `${set.reps} x ${set.weightKg}kg${rirSuffix}${machineSuffix}${dropsetSuffix}`
                     })
                     .join(', ')}
                 </p>

--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -20,6 +20,7 @@ type WorkoutSet = {
   rir: string
   machineId?: string
   machineLabel?: string
+  isDropset?: boolean
 }
 
 type WorkoutExercise = {
@@ -84,6 +85,7 @@ const mapDraftToExercise = (item: WorkoutDraft['exercises'][number]): WorkoutExe
           rir: (set.rpe ?? 1) > 1 ? String(set.rpe ?? 1) : '',
           machineId: set.machineId ?? defaultMachine?.id,
           machineLabel: set.machineLabel ?? defaultMachine?.label,
+          isDropset: set.isDropset ?? false,
         }))
       : [createSet(defaultMachine)],
   }
@@ -162,6 +164,12 @@ const IconHistory = () => (
   </svg>
 )
 
+const IconDropset = () => (
+  <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+    <path d="M12 5v14M5 15l7 7 7-7" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
 // ─── Skeleton loader ──────────────────────────────────────────────────────────
 
 const WorkoutSkeleton = () => (
@@ -211,6 +219,7 @@ type ExerciseCardProps = {
   onRemoveSet: (setId: string) => void
   onUpdateSet: (setId: string, key: 'reps' | 'kg' | 'rir', value: string) => void
   onClearDefault: (setId: string, key: 'reps' | 'kg' | 'rir') => void
+  onToggleDropset: (setId: string) => void
   onSelectMachine: (machineId: string) => void
   onDragStart: () => void
   onDragOver: (e: React.DragEvent) => void
@@ -228,6 +237,7 @@ const ExerciseCard = ({
   onRemoveSet,
   onUpdateSet,
   onClearDefault,
+  onToggleDropset,
   onSelectMachine,
   onDragStart,
   onDragOver,
@@ -352,18 +362,19 @@ const ExerciseCard = ({
           )}
 
           {/* Set grid header */}
-          <div className="grid grid-cols-[2rem_1fr_1fr_1fr_2.5rem] items-center gap-1.5 px-0.5">
+          <div className="grid grid-cols-[2rem_1fr_1fr_1fr_2rem_2.5rem] items-center gap-1.5 px-0.5">
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">#</span>
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">Reps</span>
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">kg</span>
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">RIR</span>
+            <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">DS</span>
             <span />
           </div>
 
           {/* Set rows */}
           <div className="space-y-1.5">
             {exercise.sets.map((set, setIndex) => (
-              <div className="grid grid-cols-[2rem_1fr_1fr_1fr_2.5rem] items-center gap-1.5" key={set.id}>
+              <div className="grid grid-cols-[2rem_1fr_1fr_1fr_2rem_2.5rem] items-center gap-1.5" key={set.id}>
                 {/* Set number */}
                 <div className="flex h-11 items-center justify-center rounded-xl bg-[var(--surface-2)] text-[11px] font-bold tabular-nums text-[var(--text-muted)]">
                   {setIndex + 1}
@@ -393,6 +404,22 @@ const ExerciseCard = ({
                   onFocus={() => onClearDefault(set.id, 'rir')}
                   value={set.rir}
                 />
+
+                {/* Dropset toggle */}
+                <button
+                  aria-label={`Toggle dropset for set ${setIndex + 1}`}
+                  aria-pressed={set.isDropset === true}
+                  className={cn(
+                    'flex h-11 w-8 items-center justify-center rounded-xl transition',
+                    set.isDropset
+                      ? 'bg-[var(--accent)] text-white shadow-[0_2px_8px_rgba(124,58,237,0.35)]'
+                      : 'bg-[var(--surface-2)] text-[var(--text-muted)] hover:text-[var(--accent-text)]',
+                  )}
+                  onClick={() => onToggleDropset(set.id)}
+                  type="button"
+                >
+                  <IconDropset />
+                </button>
 
                 {/* Delete set */}
                 <button
@@ -657,6 +684,21 @@ export const LogWorkoutPage = () => {
     )
   }
 
+  const toggleDropset = (exerciseId: string, setId: string) => {
+    setHasOverrides(true)
+    setItems((prev) =>
+      prev.map((item) => {
+        if (item.id !== exerciseId) return item
+        return {
+          ...item,
+          sets: item.sets.map((set) =>
+            set.id === setId ? { ...set, isDropset: !set.isDropset } : set,
+          ),
+        }
+      }),
+    )
+  }
+
   const onSave = async () => {
     if (!user || !context) return
 
@@ -681,6 +723,7 @@ export const LogWorkoutPage = () => {
             rpe: parsePositiveNumber(set.rir, 1),
             machineId: set.machineId,
             machineLabel: set.machineLabel,
+            isDropset: set.isDropset || undefined,
           })),
         })),
       })
@@ -793,6 +836,7 @@ export const LogWorkoutPage = () => {
           onRemoveSet={(setId) => removeSet(exercise.id, setId)}
           onUpdateSet={(setId, key, value) => updateSet(exercise.id, setId, key, value)}
           onClearDefault={(setId, key) => clearSetDefaultOnFocus(exercise.id, setId, key)}
+          onToggleDropset={(setId) => toggleDropset(exercise.id, setId)}
           onSelectMachine={(machineId) => updateExerciseMachine(exercise.id, machineId, exercise.availableMachines)}
           onDragOver={(e) => e.preventDefault()}
           onDragStart={() => setDraggingExerciseId(exercise.id)}

--- a/src/web/src/features/workout/workout.data.ts
+++ b/src/web/src/features/workout/workout.data.ts
@@ -19,6 +19,7 @@ export type WorkoutDraftSet = {
   rpe?: number
   machineId?: string
   machineLabel?: string
+  isDropset?: boolean
 }
 
 export type WorkoutDraftExercise = {
@@ -65,6 +66,7 @@ export type SaveWorkoutInput = {
       rpe?: number
       machineId?: string
       machineLabel?: string
+      isDropset?: boolean
     }>
   }>
 }
@@ -114,6 +116,7 @@ const toDraftSet = (item: WithId<SessionSet>): WorkoutDraftSet => ({
   rpe: item.rpe,
   machineId: item.machineId,
   machineLabel: item.machineLabel,
+  isDropset: item.isDropset,
 })
 
 export const getTodayWorkoutDraft = async (
@@ -348,6 +351,7 @@ export const saveWorkout = async (uid: string, payload: SaveWorkoutInput): Promi
         rpe: set.rpe,
         machineId: set.machineId,
         machineLabel: set.machineLabel,
+        isDropset: set.isDropset,
       })
     }
   }

--- a/src/web/src/firebase/firestore.ts
+++ b/src/web/src/firebase/firestore.ts
@@ -516,6 +516,7 @@ export const workoutStore = {
         rpe: payload.rpe,
         machineId: payload.machineId,
         machineLabel: payload.machineLabel,
+        isDropset: payload.isDropset,
       },
     );
   },

--- a/src/web/src/shared/types/firestore.ts
+++ b/src/web/src/shared/types/firestore.ts
@@ -153,6 +153,7 @@ export interface SessionSet {
   rpe?: number;
   machineId?: string;
   machineLabel?: string;
+  isDropset?: boolean;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
@@ -164,6 +165,7 @@ export interface NewSessionSetInput {
   rpe?: number;
   machineId?: string;
   machineLabel?: string;
+  isDropset?: boolean;
 }
 
 export interface ExerciseHistory {


### PR DESCRIPTION
## Summary
- Cada set tiene un botón DS (dropset) en la fila del log de workout
- `isDropset` se persiste en Firestore solo cuando `true` (false/undefined no escribe el campo)
- Indicador `↓DS` visible en el historial de sesiones
- Sin migración requerida — campo opcional, ausente = false en docs existentes

## Changes
- `firestore.ts`: `isDropset` en `upsertSet` payload (undefined-safe via stripUndefined)
- `workout.data.ts`: `isDropset` en `WorkoutDraftSet`, `toDraftSet`, `SaveWorkoutInput`, `saveWorkout`
- `LogWorkoutPage.tsx`: `isDropset` en `WorkoutSet`; `toggleDropset` handler; `IconDropset` SVG; grid actualizado a 6 columnas; botón DS por set; `isDropset || undefined` en `onSave`
- `HistoryPage.tsx`: sufijo `↓DS` en formatter de sets

## Acceptance criteria
- [x] Cada set tiene toggle visual de dropset (botón DS, estado activo con color acento)
- [x] `isDropset` se guarda en Firestore solo cuando `true`
- [x] Indicador de dropset visible en historial (`↓DS`)
- [x] Sets sin marcar no se ven afectados (campo ausente = false)
- [x] TypeScript strict mode passes

## References
Implements `solutions/23-dropset-toggle-per-set.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)