### PR TITLE
improve(#29): last session prioritizes same routine day

### DIFF
--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -736,7 +736,7 @@ export const LogWorkoutPage = () => {
     const { sourceExerciseId } = exercise
     setExerciseHistories((prev) => ({ ...prev, [sourceExerciseId]: 'loading' }))
 
-    void getExerciseHistoryForWorkout(user!.uid, sourceExerciseId, context!.dateKey)
+    void getExerciseHistoryForWorkout(user!.uid, sourceExerciseId, context!.dateKey, context!.routineDayLabel)
       .then((history) => {
         setExerciseHistories((prev) => ({ ...prev, [sourceExerciseId]: history }))
       })

--- a/src/web/src/features/workout/workout.data.ts
+++ b/src/web/src/features/workout/workout.data.ts
@@ -422,6 +422,7 @@ export const getExerciseHistoryForWorkout = async (
   uid: string,
   exerciseId: string,
   todayDateKey: DateIso,
+  routineDayLabel?: string,
 ): Promise<ExerciseHistory | null> => {
-  return workoutStore.getExerciseHistory(uid, exerciseId, todayDateKey, { maxSessions: 10 })
+  return workoutStore.getExerciseHistory(uid, exerciseId, todayDateKey, { maxSessions: 10, routineDayLabel })
 }

--- a/src/web/src/firebase/firestore.ts
+++ b/src/web/src/firebase/firestore.ts
@@ -568,7 +568,7 @@ export const workoutStore = {
     uid: string,
     exerciseId: string,
     excludeDate: DateIso,
-    options?: { maxSessions?: number },
+    options?: { maxSessions?: number; routineDayLabel?: string },
   ): Promise<ExerciseHistory | null> {
     const maxSessions = options?.maxSessions ?? 10;
     const sessionsSnapshot = await getDocs(
@@ -585,6 +585,8 @@ export const workoutStore = {
     let maxWeightKg = 0;
     let lastSessionSets: Array<{ reps: number; weightKg: number }> | null = null;
     let lastSessionDate: DateIso | null = null;
+    let sameDayLastSets: Array<{ reps: number; weightKg: number }> | null = null;
+    let sameDayLastDate: DateIso | null = null;
     let sessionCount = 0;
 
     for (const sessionDoc of sessionsSnapshot.docs) {
@@ -599,6 +601,10 @@ export const workoutStore = {
 
       sessionCount += 1;
       const sessionDate = sessionDoc.data()['date'] as DateIso;
+      const sessionDayLabel = sessionDoc.data()['routineDayLabel'] as string | undefined;
+      const isSameDay =
+        options?.routineDayLabel !== undefined &&
+        sessionDayLabel === options.routineDayLabel;
 
       for (const exerciseDoc of exercisesSnapshot.docs) {
         const setsSnapshot = await getDocs(
@@ -611,6 +617,11 @@ export const workoutStore = {
         const sessionMax = Math.max(...sets.map((s) => s.weightKg));
         if (sessionMax > maxWeightKg) maxWeightKg = sessionMax;
 
+        if (isSameDay && sameDayLastDate === null) {
+          sameDayLastDate = sessionDate;
+          sameDayLastSets = sets.map((s) => ({ reps: s.reps, weightKg: s.weightKg }));
+        }
+
         if (lastSessionDate === null) {
           lastSessionDate = sessionDate;
           lastSessionSets = sets.map((s) => ({ reps: s.reps, weightKg: s.weightKg }));
@@ -618,8 +629,11 @@ export const workoutStore = {
       }
     }
 
-    if (lastSessionDate === null) return null;
+    const resolvedDate = sameDayLastDate ?? lastSessionDate;
+    const resolvedSets = sameDayLastSets ?? lastSessionSets;
 
-    return { maxWeightKg, lastSessionSets: lastSessionSets ?? [], lastSessionDate, sessionCount };
+    if (resolvedDate === null) return null;
+
+    return { maxWeightKg, lastSessionSets: resolvedSets ?? [], lastSessionDate: resolvedDate, sessionCount };
   },
 };


### PR DESCRIPTION
## Summary
- Al expandir un ejercicio en workout, la barra "Última" ahora muestra sets de la sesión más reciente con el mismo `routineDayLabel`
- Si no existe sesión previa con el mismo día, hace fallback a la sesión más reciente (comportamiento anterior preservado)
- Cero reads adicionales a Firestore — misma query de 10 sesiones, priorización en cliente

## Changes
- `firebase/firestore.ts`: extendido `options` de `getExerciseHistory()` con `routineDayLabel?: string`; buckets same-day vs global en el loop
- `features/workout/workout.data.ts`: agregado parámetro `routineDayLabel?` a `getExerciseHistoryForWorkout()` y forwarded a la store
- `features/workout/LogWorkoutPage.tsx`: pasado `context!.routineDayLabel` como 4º argumento en `onExpandExercise`

## Acceptance criteria
- [ ] Al expandir un ejercicio en workout, la barra "Última" muestra los sets de la sesión más reciente que tenga el mismo `routineDayLabel` que el workout activo
- [ ] Si no existe sesión previa con el mismo `routineDayLabel`, se muestra la sesión más reciente como fallback (comportamiento actual)
- [ ] Ejercicios en sesiones ad-hoc (sin `routineDayLabel`) no sufren regresión: el fallback global sigue funcionando
- [ ] TypeScript strict mode compila sin errores (`npm run build` pasa)
- [ ] El número de lecturas de Firestore no aumenta respecto al comportamiento actual

## References
Implements `solutions/29-last-session-routine-day-match.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)