### PR TITLE
feat(#31): copy workout to clipboard from history detail

### DIFF
--- a/src/web/src/features/history/HistoryPage.tsx
+++ b/src/web/src/features/history/HistoryPage.tsx
@@ -1,6 +1,7 @@
 ﻿import { useEffect, useMemo, useState } from 'react'
 import { useAuth } from '../../app/providers/useAuth'
 import { Alert, AppShell, Button, Card, Drawer, EmptyState, Skeleton } from '../../shared/components'
+import { IconCheck, IconClipboard } from '../../shared/components/icons'
 import {
   getWorkoutSessionDetail,
   listWorkoutsForMonth,
@@ -43,6 +44,28 @@ const buildMonthCells = (month: Date) => {
   })
 }
 
+const formatSet = (set: {
+  reps: number
+  weightKg: number
+  rpe?: number
+  machineLabel?: string
+  isDropset?: boolean
+}): string => {
+  const rirSuffix = set.rpe === undefined ? '' : ` RIR ${set.rpe}`
+  const machineSuffix = set.machineLabel ? ` [${set.machineLabel}]` : ''
+  const dropsetSuffix = set.isDropset ? ' ↓DS' : ''
+  return `${set.reps} x ${set.weightKg}kg${rirSuffix}${machineSuffix}${dropsetSuffix}`
+}
+
+const buildClipboardText = (session: WorkoutSessionDetail): string => {
+  const header = `Workout - ${dateLabel(session.date)}`
+  const exerciseBlocks = session.exercises.map((exercise) => {
+    const setsText = exercise.sets.map((set) => `  - ${formatSet(set)}`).join('\n')
+    return `${exercise.nameSnapshot}\n${setsText}`
+  })
+  return [header, '', ...exerciseBlocks].join('\n\n')
+}
+
 export const HistoryPage = () => {
   const { user } = useAuth()
   const [month, setMonth] = useState(() => startOfMonth(new Date()))
@@ -52,6 +75,22 @@ export const HistoryPage = () => {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
   const [selectedSession, setSelectedSession] = useState<WorkoutSessionDetail | null>(null)
   const [isDetailLoading, setIsDetailLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    if (!selectedSession) return
+    const text = buildClipboardText(selectedSession)
+    try {
+      if (!navigator.clipboard) {
+        throw new Error('Clipboard not available on this browser.')
+      }
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (copyError) {
+      setError(copyError instanceof Error ? copyError.message : 'Unable to copy to clipboard.')
+    }
+  }
 
   useEffect(() => {
     const load = async () => {
@@ -181,6 +220,7 @@ export const HistoryPage = () => {
         onClose={() => {
           setSelectedSessionId(null)
           setSelectedSession(null)
+          setCopied(false)
         }}
         open={Boolean(selectedSessionId)}
         title={drawerTitle}
@@ -189,21 +229,30 @@ export const HistoryPage = () => {
 
         {!isDetailLoading && selectedSession && (
           <div className="space-y-3">
-            <p className="text-sm text-[var(--text)]">
-              {selectedSession.routineDayLabel || 'Routine day'}
-            </p>
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-[var(--text)]">
+                {selectedSession.routineDayLabel || 'Routine day'}
+              </p>
+              <Button
+                leadingIcon={
+                  copied ? (
+                    <IconCheck className="h-4 w-4" />
+                  ) : (
+                    <IconClipboard className="h-4 w-4" />
+                  )
+                }
+                onClick={() => void handleCopy()}
+                size="sm"
+                variant="ghost"
+              >
+                {copied ? 'Copiado' : 'Copiar'}
+              </Button>
+            </div>
             {selectedSession.exercises.map((exercise) => (
               <div className="rounded-lg border border-[var(--border)] p-3" key={exercise.id}>
                 <p className="text-sm font-semibold text-[var(--text-strong)]">{exercise.nameSnapshot}</p>
                 <p className="text-xs text-[var(--text-muted)]">
-                  {exercise.sets
-                    .map((set) => {
-                      const rirSuffix = set.rpe === undefined ? '' : ` RIR ${set.rpe}`
-                      const machineSuffix = set.machineLabel ? ` [${set.machineLabel}]` : ''
-                      const dropsetSuffix = set.isDropset ? ' ↓DS' : ''
-                      return `${set.reps} x ${set.weightKg}kg${rirSuffix}${machineSuffix}${dropsetSuffix}`
-                    })
-                    .join(', ')}
+                  {exercise.sets.map((set) => formatSet(set)).join(', ')}
                 </p>
               </div>
             ))}

--- a/src/web/src/shared/components/icons.tsx
+++ b/src/web/src/shared/components/icons.tsx
@@ -63,3 +63,16 @@ export const IconChart = (props: IconProps) => (
     <path d="M4 20V8M10 20V4M16 20v-7M22 20V11" />
   </svg>
 )
+
+export const IconClipboard = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <rect height="14" rx="2" ry="2" width="14" x="5" y="5" />
+    <path d="M10 5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2" />
+  </svg>
+)
+
+export const IconCheck = (props: IconProps) => (
+  <svg aria-hidden="true" {...baseProps} {...props}>
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+)


### PR DESCRIPTION
## Summary
- Agrega botón "Copiar" dentro del drawer de historial que formatea toda la sesión como texto legible
- Feedback visual: el icono cambia a checkmark + "Copiado" durante 2 segundos tras copiar
- Si `navigator.clipboard` no está disponible, muestra el `Alert` de error ya existente
- No requiere cambios en el componente `Drawer` compartido

## Changes
- `shared/components/icons.tsx`: agregados `IconClipboard` e `IconCheck` SVG
- `features/history/HistoryPage.tsx`:
  - Extraída `formatSet()` como función pura (antes era lambda inline)
  - Agregada `buildClipboardText()` que genera el texto completo de la sesión
  - Agregados estado `copied` y handler `handleCopy` async
  - Drawer `onClose` resetea `copied` a `false`
  - Botón "Copiar/Copiado" con icono en el drawer detail block

## Acceptance criteria
- [ ] Botón "Copiar" visible en el drawer de detalle del dia en historial
- [ ] El texto copiado incluye: fecha, nombre de ejercicio, reps, peso, maquina (si aplica), dropset marker (si aplica), RIR (si aplica)
- [ ] Se muestra feedback visual tras copiar (icono cambia a checkmark + label "Copiado" por 2 segundos)
- [ ] Funciona en mobile (Android Chrome, iOS Safari — ambos soportan `navigator.clipboard` en contextos seguros HTTPS)
- [ ] Si clipboard no esta disponible, muestra `Alert` de error con `tone="error"`

## References
Implements `solutions/31-copy-workout-to-clipboard.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)