### PR TITLE
improve(#38): remove RIR column from workout log UI

### DIFF
--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -418,11 +418,10 @@ const ExerciseCard = ({
           )}
 
           {/* Set grid header */}
-          <div className="grid grid-cols-[2rem_1fr_1fr_1fr_2rem_2.5rem] items-center gap-1.5 px-0.5">
+          <div className="grid grid-cols-[2rem_1fr_1fr_2rem_2.5rem] items-center gap-1.5 px-0.5">
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">#</span>
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">Reps</span>
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">kg</span>
-            <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">RIR</span>
             <span className="text-center text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">DS</span>
             <span />
           </div>
@@ -430,7 +429,7 @@ const ExerciseCard = ({
           {/* Set rows */}
           <div className="space-y-1.5">
             {exercise.sets.map((set, setIndex) => (
-              <div className="grid grid-cols-[2rem_1fr_1fr_1fr_2rem_2.5rem] items-center gap-1.5" key={set.id}>
+              <div className="grid grid-cols-[2rem_1fr_1fr_2rem_2.5rem] items-center gap-1.5" key={set.id}>
                 {/* Set number */}
                 <div className="flex h-11 items-center justify-center rounded-xl bg-[var(--surface-2)] text-[11px] font-bold tabular-nums text-[var(--text-muted)]">
                   {setIndex + 1}
@@ -451,14 +450,6 @@ const ExerciseCard = ({
                   onChange={(v) => onUpdateSet(set.id, 'kg', v)}
                   onFocus={() => onClearDefault(set.id, 'kg')}
                   value={set.kg}
-                />
-
-                {/* RIR */}
-                <NumInput
-                  label={`Set ${setIndex + 1} RIR for ${exercise.name}`}
-                  onChange={(v) => onUpdateSet(set.id, 'rir', v)}
-                  onFocus={() => onClearDefault(set.id, 'rir')}
-                  value={set.rir}
                 />
 
                 {/* Dropset toggle */}


### PR DESCRIPTION
## Summary
- La columna RIR (Reps In Reserve) fue removida del grid de sets en el log de workout
- El grid pasó de 6 columnas (`#`, `Reps`, `kg`, `RIR`, `DS`, delete) a 5 columnas
- La lógica interna de `rir` y el mapeo a `rpe` al guardar permanecen intactos

## Changes
- `LogWorkoutPage.tsx`: Actualizado grid template de `grid-cols-[2rem_1fr_1fr_1fr_2rem_2.5rem]` a `grid-cols-[2rem_1fr_1fr_2rem_2.5rem]` en header y filas
- `LogWorkoutPage.tsx`: Eliminado `<span>RIR</span>` del header y `<NumInput>` de RIR de cada fila

## Acceptance criteria
- [x] La columna RIR no aparece en el header del grid de sets
- [x] La columna RIR no aparece en ninguna fila de set
- [x] El grid de 5 columnas (`#`, `Reps`, `kg`, `DS`, delete) se alinea correctamente
- [x] Al guardar un workout, el campo `rpe` sigue persistiéndose con el valor por defecto `1`
- [x] No regressions en la lógica de dropset toggle ni delete set
- [x] TypeScript strict mode pasa sin errores

## References
Implements `solutions/38-remove-rir-column-workout-log.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)