### PR TITLE
fix(#36): filter history bar by selected machine

### DIFF
--- a/src/web/src/features/workout/LogWorkoutPage.tsx
+++ b/src/web/src/features/workout/LogWorkoutPage.tsx
@@ -403,17 +403,23 @@ const ExerciseCard = ({
               {history === 'loading' && (
                 <div className="h-7 animate-pulse rounded-xl bg-[var(--surface-2)]" />
               )}
-              {history && history !== 'loading' && history.lastSessionSets.length > 0 && (
-                <div className="flex items-center gap-2 rounded-xl bg-[var(--surface-2)] px-3 py-2">
-                  <IconHistory />
-                  <span className="text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)]">
-                    Última
-                  </span>
-                  <span className="text-xs font-semibold text-[var(--text-strong)]">
-                    {history.lastSessionSets.map((s) => `${s.reps}×${s.weightKg}kg`).join(' / ')}
-                  </span>
-                </div>
-              )}
+              {history && history !== 'loading' && history.lastSessionSets.length > 0 && (() => {
+                const visibleHistorySets =
+                  activeMachineId && history.lastSessionSets.some((s) => s.machineId === activeMachineId)
+                    ? history.lastSessionSets.filter((s) => s.machineId === activeMachineId)
+                    : history.lastSessionSets
+                return visibleHistorySets.length > 0 ? (
+                  <div className="flex items-center gap-2 rounded-xl bg-[var(--surface-2)] px-3 py-2">
+                    <IconHistory />
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)]">
+                      Última
+                    </span>
+                    <span className="text-xs font-semibold text-[var(--text-strong)]">
+                      {visibleHistorySets.map((s) => `${s.reps}×${s.weightKg}kg`).join(' / ')}
+                    </span>
+                  </div>
+                ) : null
+              })()}
             </>
           )}
 

--- a/src/web/src/firebase/firestore.ts
+++ b/src/web/src/firebase/firestore.ts
@@ -613,7 +613,7 @@ export const workoutStore = {
 
         if (lastSessionDate === null) {
           lastSessionDate = sessionDate;
-          lastSessionSets = sets.map((s) => ({ reps: s.reps, weightKg: s.weightKg }));
+          lastSessionSets = sets.map((s) => ({ reps: s.reps, weightKg: s.weightKg, machineId: s.machineId }));
         }
       }
     }

--- a/src/web/src/shared/types/firestore.ts
+++ b/src/web/src/shared/types/firestore.ts
@@ -172,7 +172,7 @@ export interface NewSessionSetInput {
 
 export interface ExerciseHistory {
   maxWeightKg: number;
-  lastSessionSets: Array<{ reps: number; weightKg: number }>;
+  lastSessionSets: Array<{ reps: number; weightKg: number; machineId?: string }>;
   lastSessionDate: DateIso;
   sessionCount: number;
 }


### PR DESCRIPTION
## Summary
- La barra de historia "Última" ahora filtra sets por la máquina actualmente seleccionada
- Si no hay sets con la máquina seleccionada (sesiones antiguas), muestra todos los sets como fallback
- Zero re-fetches: el filtrado es client-side y reactivo a cambios de máquina

## Changes
- `shared/types/firestore.ts`: Agregado `machineId?: string` al tipo de items en `ExerciseHistory.lastSessionSets`
- `firebase/firestore.ts`: `getExerciseHistory` ahora incluye `machineId` en el mapping de sets
- `LogWorkoutPage.tsx`: History bar filtra `visibleHistorySets` por `activeMachineId` con fallback a todos los sets

## Acceptance criteria
- [x] Seleccionar "Máquina 2" muestra solo los sets de esa máquina en la barra de historia
- [x] Cambiar de máquina actualiza la barra inmediatamente — sin re-fetch
- [x] Si no existe historial para la máquina seleccionada, muestra el historial completo (fallback)
- [x] Ejercicios sin máquina configurada muestran historial completo sin cambios
- [x] `machineId` en `lastSessionSets` es optional — no rompe callers existentes
- [x] TypeScript strict mode pasa sin errores

## References
Implements `solutions/36-last-session-filtered-by-machine.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)