### PR TITLE
feat(#37): copy workout button in history detail drawer

### DIFF
--- a/src/web/src/features/history/HistoryPage.tsx
+++ b/src/web/src/features/history/HistoryPage.tsx
@@ -23,6 +23,21 @@ const dateLabel = (dateKey: string): string => {
   }).format(new Date(year, (month ?? 1) - 1, day ?? 1))
 }
 
+const buildWorkoutText = (session: WorkoutSessionDetail): string => {
+  const header = `${dateLabel(session.date)} — ${session.routineDayLabel ?? 'Workout'}`
+  const exerciseLines = session.exercises.map((exercise) => {
+    const setsText = exercise.sets
+      .map((set) => {
+        const machineSuffix = set.machineLabel ? ` [${set.machineLabel}]` : ''
+        const dropsetSuffix = set.isDropset ? ' DS' : ''
+        return `  ${set.reps} x ${set.weightKg}kg${machineSuffix}${dropsetSuffix}`
+      })
+      .join('\n')
+    return `${exercise.nameSnapshot}\n${setsText}`
+  })
+  return `${header}\n\n${exerciseLines.join('\n\n')}`
+}
+
 const buildMonthCells = (month: Date) => {
   const firstDay = startOfMonth(month)
   const offset = (firstDay.getDay() + 6) % 7
@@ -52,6 +67,7 @@ export const HistoryPage = () => {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
   const [selectedSession, setSelectedSession] = useState<WorkoutSessionDetail | null>(null)
   const [isDetailLoading, setIsDetailLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     const load = async () => {
@@ -101,6 +117,17 @@ export const HistoryPage = () => {
 
     void loadDetail()
   }, [user, selectedSessionId])
+
+  const handleCopy = async () => {
+    if (!selectedSession) return
+    try {
+      await navigator.clipboard.writeText(buildWorkoutText(selectedSession))
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setError('No se pudo copiar al portapapeles.')
+    }
+  }
 
   const monthCells = useMemo(() => buildMonthCells(month), [month])
 
@@ -189,9 +216,14 @@ export const HistoryPage = () => {
 
         {!isDetailLoading && selectedSession && (
           <div className="space-y-3">
-            <p className="text-sm text-[var(--text)]">
-              {selectedSession.routineDayLabel || 'Routine day'}
-            </p>
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-[var(--text)]">
+                {selectedSession.routineDayLabel || 'Routine day'}
+              </p>
+              <Button onClick={handleCopy} size="sm" variant="secondary">
+                {copied ? '¡Copiado!' : 'Copy'}
+              </Button>
+            </div>
             {selectedSession.exercises.map((exercise) => (
               <div className="rounded-lg border border-[var(--border)] p-3" key={exercise.id}>
                 <p className="text-sm font-semibold text-[var(--text-strong)]">{exercise.nameSnapshot}</p>


### PR DESCRIPTION
## Summary
- Agrega un botón "Copy" en el drawer de detalle de workout en `/history`
- El workout se formatea como texto plano multilínea y se copia al clipboard
- Feedback visual: el botón muestra "¡Copiado!" por 2 segundos tras copia exitosa

## Changes
- `HistoryPage.tsx`: Función `buildWorkoutText` que formatea fecha, rutina, ejercicios y sets
- `HistoryPage.tsx`: Estado `copied` y handler `handleCopy` con manejo de errores
- `HistoryPage.tsx`: Botón `Button` (secondary/sm) en la parte superior del drawer content

## Acceptance criteria
- [x] El drawer muestra un botón "Copy" cuando hay datos cargados
- [x] Al pulsar, el texto del workout se copia al clipboard via `navigator.clipboard.writeText`
- [x] El formato incluye: fecha, etiqueta de rutina, nombre de ejercicio, sets con `reps x kg`
- [x] El botón muestra "¡Copiado!" por 2 segundos, luego vuelve a "Copy"
- [x] Si el clipboard falla, se muestra el mensaje de error existente en la página
- [x] El botón no aparece mientras los datos están cargando (`isDetailLoading`)
- [x] TypeScript strict mode pasa sin errores

## References
Implements `solutions/37-copy-workout-button-history-drawer.md`
Related: #31 (same clipboard feature, covered by PR #34)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)